### PR TITLE
Adding base Control class

### DIFF
--- a/PhotonUI.Demo/PhotonUI.Demo.csproj
+++ b/PhotonUI.Demo/PhotonUI.Demo.csproj
@@ -36,4 +36,8 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <ProjectReference Include="..\PhotonUI\PhotonUI.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/PhotonUI.sln
+++ b/PhotonUI.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 18.0.11217.181
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotonUI.Demo", "PhotonUI.Demo\PhotonUI.Demo.csproj", "{21F206A8-7BB3-66BA-84C5-36E5EA19BC60}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotonUI", "PhotonUI\PhotonUI.csproj", "{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,6 +16,10 @@ Global
 		{21F206A8-7BB3-66BA-84C5-36E5EA19BC60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{21F206A8-7BB3-66BA-84C5-36E5EA19BC60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{21F206A8-7BB3-66BA-84C5-36E5EA19BC60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PhotonUI/Controls/Control.cs
+++ b/PhotonUI/Controls/Control.cs
@@ -1,0 +1,166 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using NucleusAF.Photon.Models;
+using SDL3;
+using System.ComponentModel;
+
+namespace NucleusAF.Photon.Controls
+{
+    public enum TunnelDirection
+    {
+        TopDown,
+        BottomUp
+    }
+
+    public partial class Control(IServiceProvider serviceProvider)
+        : ObservableObject, IDisposable
+    {
+        protected readonly IServiceProvider ServiceProvider = serviceProvider;
+
+        [ObservableProperty] private Control? parent = null;
+        [ObservableProperty] private string name = typeof(Control).Name;
+        [ObservableProperty] private object? dataContext = null;
+
+        [ObservableProperty] private float x = 0;
+        [ObservableProperty] private float y = 0;
+
+        [ObservableProperty] private bool isVisible = true;
+        [ObservableProperty] private bool isEnabled = true;
+        [ObservableProperty] private bool isFocused = false;
+
+        #region Control: Style Properties
+
+        [ObservableProperty] private float minWidth;
+        [ObservableProperty] private float minHeight;
+        [ObservableProperty] private float maxWidth;
+        [ObservableProperty] private float maxHeight;
+
+        [ObservableProperty] private bool focusOnHover;
+        [ObservableProperty] private int tabIndex;
+        [ObservableProperty] private int zIndex;
+
+        [ObservableProperty] private Thickness margin;
+        [ObservableProperty] private Thickness padding;
+
+        [ObservableProperty] private SDL.Color backgroundColor;
+        [ObservableProperty] private float opacity;
+
+        [ObservableProperty] private bool clipToBounds;
+        [ObservableProperty] private bool isHitTestVisible;
+
+        [ObservableProperty] private SDL.SystemCursor cursor;
+
+        #endregion
+
+        #region Control: Actions
+
+        public Action<Control>? InitializedAction { get; set; }
+        public Action<Control>? MeasuredAction { get; set; }
+        public Action<Control>? ArrangedAction { get; set; }
+        public Action<Control>? RenderedAction { get; set; }
+
+        #endregion
+
+        #region Control: States
+
+        public bool IsOpaque => this.IsVisible && this.BackgroundColor.A == 255 && this.Opacity == 1f;
+        public bool IsInteractable => this.IsEnabled && this.IsVisible && this.IsHitTestVisible;
+
+        public bool IsInitialized { get; protected set; } = false;
+        public bool IsMeasureDirty { get; set; } = true;
+        public bool IsLayoutDirty { get; set; } = true;
+        public bool IsRenderDirty { get; set; } = true;
+        public bool IsBoundryDirty { get; set; } = true;
+
+        #endregion
+
+        #region Control: Framework
+
+        public virtual bool TunnelControls(Func<Control, bool> tunneler, TunnelDirection direction = TunnelDirection.TopDown)
+            => tunneler(this);
+        
+        public virtual void RequestMeasure()
+        {
+            this.TunnelControls(control =>
+            {
+                control.IsMeasureDirty = true;
+                return true;
+            });
+        }
+        public virtual void RequestArrange()
+        {
+            this.TunnelControls(control =>
+            {
+                control.IsLayoutDirty = true;
+                return true;
+            });
+        }
+        public virtual void RequestRender(bool invalidate = true)
+        {
+            this.IsRenderDirty = true;
+
+            this.TunnelControls(control =>
+            {
+                if (control != this)
+                    control.RequestRender(false);
+                return true;
+            });
+        }
+
+        #endregion
+
+        #region Control: Hooks
+
+        protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+        {
+            if (!this.IsInitialized)
+                return;
+
+            base.OnPropertyChanged(e);
+
+            bool invalidateMeasure = false;
+            bool invalidateLayout = false;
+            bool invalidateRender = false;
+
+            switch (e.PropertyName)
+            {
+                case nameof(this.X):
+                case nameof(this.Y):
+                case nameof(this.Margin):
+                case nameof(this.Padding):
+                case nameof(this.MinWidth):
+                case nameof(this.MinHeight):
+                case nameof(this.MaxWidth):
+                case nameof(this.MaxHeight):
+                    invalidateMeasure = true;
+                    invalidateLayout = true;
+                    invalidateRender = true;
+                    break;
+
+                case nameof(this.IsVisible):
+                case nameof(this.IsEnabled):
+                case nameof(this.Opacity):
+                case nameof(this.BackgroundColor):
+                case nameof(this.ClipToBounds):
+                case nameof(this.ZIndex):
+                    invalidateRender = true;
+                    break;
+            }
+
+            if (invalidateMeasure)
+                this.Parent?.RequestMeasure();
+
+            if (invalidateLayout)
+                this.Parent?.RequestArrange();
+
+            if (invalidateRender)
+                this.RequestRender(true);
+        }
+
+        public virtual void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+}

--- a/PhotonUI/Models/Size.cs
+++ b/PhotonUI/Models/Size.cs
@@ -1,0 +1,34 @@
+﻿namespace NucleusAF.Photon.Models
+{
+    public struct Size
+    {
+        public float Width { get; set; }
+        public float Height { get; set; }
+
+        public Size(float width, float height)
+        {
+            this.Width = width;
+            this.Height = height;
+        }
+        public Size(float extent)
+        {
+            this.Width = extent;
+            this.Height = extent;
+        }
+
+        public static Size operator +(Size a, Size b)
+            => new(a.Width + b.Width, a.Height + b.Height);
+        public static Size operator -(Size a, Size b)
+            => new(Math.Max(0, a.Width - b.Width), Math.Max(0, a.Height - b.Height));
+
+        public static Size Empty { get; } = new Size(0, 0);
+        public readonly bool IsEmpty => this.Width == 0 && this.Height == 0;
+
+        public override readonly string ToString() => $"{this.Width}x{this.Height}";
+
+        public readonly Size Inflate(Thickness thickness)
+            => new(this.Width + thickness.Horizontal, this.Height + thickness.Vertical);
+        public readonly Size Deflate(Thickness thickness)
+            => new(Math.Max(0, this.Width - thickness.Horizontal), Math.Max(0, this.Height - thickness.Vertical));
+    }
+}

--- a/PhotonUI/Models/Thickness.cs
+++ b/PhotonUI/Models/Thickness.cs
@@ -1,0 +1,31 @@
+﻿namespace NucleusAF.Photon.Models
+{
+    public readonly struct Thickness(float left, float top, float right, float bottom)
+    {
+        public float Left { get; } = left;
+        public float Top { get; } = top;
+        public float Right { get; } = right;
+        public float Bottom { get; } = bottom;
+
+        public static Thickness operator +(Thickness a, Thickness b)
+            => new(
+                a.Left + b.Left,
+                a.Top + b.Top,
+                a.Right + b.Right,
+                a.Bottom + b.Bottom);
+        public static Thickness operator -(Thickness a, Thickness b)
+            => new(
+                a.Left - b.Left,
+                a.Top - b.Top,
+                a.Right - b.Right,
+                a.Bottom - b.Bottom);
+
+        public Thickness(float uniform) : this(uniform, uniform, uniform, uniform) { }
+        public Thickness(float lr, float tb) : this(lr, tb, lr, tb) { }
+
+        public float Horizontal => this.Left + this.Right;
+        public float Vertical => this.Top + this.Bottom;
+
+        public static Thickness Empty => new(0);
+    }
+}

--- a/PhotonUI/PhotonUI.csproj
+++ b/PhotonUI/PhotonUI.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--Dependency Injection-->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <!--MVVM Community Toolkit -->
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <!-- Core SDL3 C# bindings -->
+    <PackageReference Include="SDL3-CS" Version="3.3.2.1" />
+    <PackageReference Include="SDL3-CS.Native" Version="3.3.2" />
+    <PackageReference Include="SDL3-CS.Native.Image" Version="3.2.4" />
+    <PackageReference Include="SDL3-CS.Native.Mixer" Version="2.8.1.1" />
+    <PackageReference Include="SDL3-CS.Native.TTF" Version="3.2.2" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Description
This PR introduces the minimal Control base class along with essential supporting types and enums to establish a compilable foundation for the UI framework. It provides the core observable properties, basic lifecycle hooks, and stub framework methods needed for future expansion of layout, rendering, and event propagation.

## Related Issue
- Resolves #7

## Motivation and Context
This change sets up the foundational structure of the UI framework, allowing subsequent features to build on a clean, minimal, and compilable base. It ensures that core controls and supporting classes are available for future development without introducing complex behaviors yet.

## How Has This Been Tested?
- Verified that the Control class and supporting types compile successfully in the project.
- Confirmed that observable properties generate correctly and do not cause compiler errors.
- Stub framework methods can be called without runtime exceptions.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.
