### PR TITLE
Adding Presenter Control

### DIFF
--- a/PhotonUI/Controls/Presenter.cs
+++ b/PhotonUI/Controls/Presenter.cs
@@ -1,0 +1,48 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace PhotonUI.Controls
+{
+    public partial class Presenter(IServiceProvider serviceProvider)
+        : Control(serviceProvider)
+    {
+        [ObservableProperty] private Control? child;
+
+        partial void OnChildChanging(Control? value)
+        {
+            if (child != null)
+                child.Parent = null;
+        }
+        partial void OnChildChanged(Control? value)
+        {
+            if (value != null)
+            {
+                if (value.Parent != null)
+                    throw new InvalidOperationException("Control already has a parent.");
+
+                value.Parent = this;
+
+                this.RequestArrange();
+            }
+        }
+
+        #region Presenter: Framework
+
+        public override bool TunnelControls(Func<Control, bool> traveler, TunnelDirection direction = TunnelDirection.TopDown)
+        {
+            if (direction == TunnelDirection.TopDown)
+            {
+                if (!traveler(this)) return false;
+                if (this.Child != null && !this.Child.TunnelControls(traveler, direction)) return false;
+            }
+            else
+            {
+                if (this.Child != null && !this.Child.TunnelControls(traveler, direction)) return false;
+                if (!traveler(this)) return false;
+            }
+
+            return true;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Description
This PR introduces the `Presenter` control class, a subclass of `Control`, which manages a single child control. The class ensures that a child is not assigned if it already has a parent and provides recursive traversal through the `TunnelControls` method.

## Related Issue
- Resolves #11

## Motivation and Context
This feature allows for hierarchical grouping of controls, enabling a simple parent-child relationship where the parent (`Presenter`) holds a single child control. The `Presenter` facilitates more complex layout or control groups in the future.

## How Has This Been Tested?
- Verified that the `Presenter` can successfully assign and manage a child control.
- Confirmed that a child control can't be assigned if it already has a parent.
- Ensured that the `TunnelControls` method works as expected, traversing the `Presenter` and its child in both directions.
- Tested lifecycle hooks for the child control, ensuring proper updates during the change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.
