### PR TITLE
Adding lifecycle framework hooks and overridables 

### DIFF
--- a/PhotonUI/Controls/Control.cs
+++ b/PhotonUI/Controls/Control.cs
@@ -66,6 +66,10 @@ namespace PhotonUI.Controls
         public Action<Control>? ArrangedAction { get; set; }
         public Action<Control>? RenderedAction { get; set; }
 
+        public Action<Control>? TickAction { get; set; }
+        public Action<Control>? LateTickAction { get; set; }
+        public Action<Control>? PostTickAction { get; set; }
+
         #endregion
 
         #region Control: States
@@ -230,6 +234,40 @@ namespace PhotonUI.Controls
             });
         }
 
+        public virtual void FrameworkInitialize(Window window)
+        {
+            ArgumentNullException.ThrowIfNull(window);
+
+            if (!this.IsInitialized)
+            {
+                this.Window = window;
+                this.IsInitialized = true;
+
+                this.OnInitialize(window);
+
+                window.SetTabStop(this, this.TabIndex);
+
+                if (this.IsFocused)
+                    window.SetFocus(this);
+            }
+
+            this.TunnelControls(control =>
+            {
+                if (control != this)
+                    control.FrameworkInitialize(window);
+                return true;
+            });
+
+            this.InitializedAction?.Invoke(this);
+        }
+        public virtual void FrameworkTick(Window window) { }
+        public virtual void FrameworkIntrinsic(Window window, Size content) { }
+        public virtual void FrameworkMeasure(Window window) { }
+        public virtual void FrameworkArrange(Window window, SDL.FPoint anchor) { }
+        public virtual void FrameworkLateTick(Window window) { }
+        public virtual void FrameworkRender(Window window, SDL.Rect? clipRect) { }
+        public virtual void FrameworkPostTick(Window window) { }
+
         #endregion
 
         #region Control: Hooks
@@ -285,6 +323,14 @@ namespace PhotonUI.Controls
                 this.RequestRender(true);
         }
 
+        public virtual void OnInitialize(Window window) { }
+        public virtual void OnTick(Window window) { }
+        public virtual void OnMeasure(Window window) { }
+        public virtual void OnArrange(Window window, SDL.FPoint anchor) { }
+        public virtual void OnLateTick(Window window) { }
+        public virtual void OnRender(Window window, SDL.Rect? clipRect = null) { }
+        public virtual void OnPostTick(Window window) { }
+        
         public virtual void Dispose()
         {
             GC.SuppressFinalize(this);


### PR DESCRIPTION
## Description
This PR introduces the foundational lifecycle pipeline for the `Control` class. It defines the framework-level execution methods (`FrameworkInitialize`, `FrameworkTick`, `FrameworkMeasure`, `FrameworkArrange`, `FrameworkLateTick`, `FrameworkRender`, and `FrameworkPostTick`) along with their corresponding virtual `On*` hooks.

`FrameworkInitialize` now associates a control with a `Window`, marks it as initialized, registers its tab stop, optionally sets focus, and propagates initialization through the control tree.

Tick-related delegate actions (`TickAction`, `LateTickAction`, `PostTickAction`) have also been added to support future extensibility.

No lifecycle orchestration logic is implemented in this PR—this change establishes structure and extension points only.

## Related Issue
- Resolves #17

## Motivation and Context
The framework requires a clearly defined lifecycle pipeline before implementing layout, rendering, and update orchestration. By introducing structured `Framework*` methods and overridable hooks, we formalize how controls participate in initialization, layout passes, ticking, and rendering.

This provides a stable architectural backbone for future features without prematurely coupling behavior.

## How Has This Been Tested?
- Verified no compilation errors

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.
