### PR TITLE
Adding framework and platform base events

### DIFF
--- a/PhotonUI/Events/FrameworkEventArgs.cs
+++ b/PhotonUI/Events/FrameworkEventArgs.cs
@@ -1,0 +1,8 @@
+﻿namespace NucleusAF.Photon.Events
+{
+    public class FrameworkEventArgs : EventArgs
+    {
+        public bool Handled { get; set; } = false;
+        public bool Preview { get; set; } = false;
+    }
+}

--- a/PhotonUI/Events/PlatformEventArgs.cs
+++ b/PhotonUI/Events/PlatformEventArgs.cs
@@ -1,0 +1,10 @@
+﻿using SDL3;
+
+namespace NucleusAF.Photon.Events
+{
+    public class PlatformEventArgs(SDL.Event nativeEvent)
+        : FrameworkEventArgs
+    {
+        public SDL.Event NativeEvent { get; } = nativeEvent;
+    }
+}


### PR DESCRIPTION
## Description
Introduces foundational event argument types for PhotonUI:

* `FrameworkEventArgs` – base class for all framework events, includes `Handled` and `Preview` flags.
* `PlatformEventArgs` – extends `FrameworkEventArgs` to represent events coming from SDL, exposing the native event.

This provides a consistent structure for handling and previewing events across the framework.

## Related Issue
- Resolves #19

## Motivation and Context
Establishes a base event system so that both internal and platform-originating events can be handled uniformly and extended in future work.

## How Has This Been Tested?
- Verified that `FrameworkEventArgs` can be instantiated and its properties set/read.
- Verified that `PlatformEventArgs` exposes the native SDL event correctly.
- Checked that inheritance from `FrameworkEventArgs` works as expected.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.
