### PR TITLE
Adding focus events to controls

### DIFF
--- a/PhotonUI/Controls/Control.cs
+++ b/PhotonUI/Controls/Control.cs
@@ -1,4 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Events;
+using PhotonUI.Events.Framework;
 using PhotonUI.Exceptions;
 using PhotonUI.Interfaces;
 using PhotonUI.Models;
@@ -69,6 +71,9 @@ namespace PhotonUI.Controls
         public Action<Control>? TickAction { get; set; }
         public Action<Control>? LateTickAction { get; set; }
         public Action<Control>? PostTickAction { get; set; }
+
+        public Action<FocusGainedEventArgs>? FocusGainedAction { get; set; }
+        public Action<FocusLostEventArgs>? FocusLostAction { get; set; }
 
         #endregion
 
@@ -330,7 +335,24 @@ namespace PhotonUI.Controls
         public virtual void OnLateTick(Window window) { }
         public virtual void OnRender(Window window, SDL.Rect? clipRect = null) { }
         public virtual void OnPostTick(Window window) { }
-        
+        public virtual void OnEvent(Window window, FrameworkEventArgs e)
+        {
+            if (e.Handled || e.Preview) return;
+
+            switch (e)
+            {
+                case FocusGainedEventArgs focusGained:
+                    this.IsFocused = true;
+                    this.FocusGainedAction?.Invoke(focusGained);
+                    break;
+
+                case FocusLostEventArgs focusLost:
+                    this.IsFocused = false;
+                    this.FocusLostAction?.Invoke(focusLost);
+                    break;
+            }
+        }
+
         public virtual void Dispose()
         {
             GC.SuppressFinalize(this);

--- a/PhotonUI/Controls/Window.cs
+++ b/PhotonUI/Controls/Window.cs
@@ -1,5 +1,5 @@
-﻿using SDL3;
-using System.Linq.Expressions;
+﻿using PhotonUI.Events.Framework;
+using SDL3;
 
 namespace PhotonUI.Controls
 {
@@ -125,7 +125,9 @@ namespace PhotonUI.Controls
         {
             if (this.FocusedControl == control) return;
 
+            this.FocusedControl?.OnEvent(this, new FocusLostEventArgs(this.FocusedControl));
             this.FocusedControl = control;
+            this.FocusedControl?.OnEvent(this, new FocusGainedEventArgs(this.FocusedControl));
 
             if (control != null)
             {

--- a/PhotonUI/Events/Framework/FocusGainedEventArgs.cs
+++ b/PhotonUI/Events/Framework/FocusGainedEventArgs.cs
@@ -1,0 +1,10 @@
+﻿using PhotonUI.Controls;
+
+namespace PhotonUI.Events.Framework
+{
+    public class FocusGainedEventArgs(Control target)
+        : FrameworkEventArgs
+    {
+        public Control Target = target;
+    }
+}

--- a/PhotonUI/Events/Framework/FocusLostEventArgs.cs
+++ b/PhotonUI/Events/Framework/FocusLostEventArgs.cs
@@ -1,0 +1,10 @@
+﻿using PhotonUI.Controls;
+
+namespace PhotonUI.Events.Framework
+{
+    public class FocusLostEventArgs(Control target)
+        : FrameworkEventArgs
+    {
+        public Control Target = target;
+    }
+}

--- a/PhotonUI/Events/FrameworkEventArgs.cs
+++ b/PhotonUI/Events/FrameworkEventArgs.cs
@@ -1,4 +1,4 @@
-﻿namespace NucleusAF.Photon.Events
+﻿namespace PhotonUI.Events
 {
     public class FrameworkEventArgs : EventArgs
     {

--- a/PhotonUI/Events/PlatformEventArgs.cs
+++ b/PhotonUI/Events/PlatformEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿using SDL3;
 
-namespace NucleusAF.Photon.Events
+namespace PhotonUI.Events
 {
     public class PlatformEventArgs(SDL.Event nativeEvent)
         : FrameworkEventArgs


### PR DESCRIPTION
## Description
This change introduces framework-level focus events for controls:
- `FocusGainedEventArgs` and `FocusLostEventArgs` are added to allow controls to respond when they gain or lose focus.
- `Control` class now exposes `FocusGainedAction` and `FocusLostAction` for hooking into these events.
- `Window.SetFocus` is updated to fire these events appropriately when focus changes.
- These events integrate with the existing `FrameworkEventArgs` system, supporting previewing and handling.

## Related Issue
- Resolves #21

## Motivation and Context
Controls need a way to detect focus changes in a consistent, framework-level manner. This allows developers to react to focus acquisition and loss without manually tracking state in each control.

## How Has This Been Tested?
- Manually created multiple controls in a window and switched focus between them.
- Verified that `FocusGainedAction` and `FocusLostAction` are invoked correctly.
- Confirmed that the `IsFocused` state of controls updates appropriately.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.