### PR TITLE
Formalized control rendering lifecycle

### DIFF
--- a/PhotonUI/Events/Framework/ChildPropertyChangedEventArgs.cs
+++ b/PhotonUI/Events/Framework/ChildPropertyChangedEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using PhotonUI.Controls;
+using System.ComponentModel;
+
+namespace PhotonUI.Events.Framework
+{
+    public class ChildPropertyChangedEventArgs(Control child, PropertyChangedEventArgs propertyArgs) : FrameworkEventArgs
+    {
+        public Control Child { get; } = child
+            ?? throw new ArgumentNullException(nameof(child));
+        public PropertyChangedEventArgs PropertyArgs { get; } = propertyArgs
+            ?? throw new ArgumentNullException(nameof(propertyArgs));
+        public string PropertyName { get; } = propertyArgs.PropertyName
+            ?? string.Empty;
+    }
+}

--- a/PhotonUI/Extensions/FRect.cs
+++ b/PhotonUI/Extensions/FRect.cs
@@ -1,0 +1,129 @@
+﻿using PhotonUI.Models;
+using SDL3;
+
+namespace PhotonUI.Extensions
+{
+    public static class Rect
+    {
+        public static SDL.Rect Offset(this SDL.Rect rect, float dx, float dy)
+            => new() { X = rect.X + (int)dx, Y = rect.Y + (int)dy, W = rect.W, H = rect.H };
+        public static SDL.Rect Deflate(this SDL.Rect rect, float left, float top, float right, float bottom)
+            => new()
+            {
+                X = rect.X + (int)left,
+                Y = rect.Y + (int)top,
+                W = rect.W - (int)(left + right),
+                H = rect.H - (int)(top + bottom)
+            };
+        public static SDL.Rect Inflate(this SDL.Rect rect, float left, float top, float right, float bottom)
+            => rect.Deflate(-left, -top, -right, -bottom);
+
+        public static SDL.Rect Offset(this SDL.Rect rect, Size size)
+            => rect.Offset(size.Width, size.Height);
+        public static SDL.Rect Deflate(this SDL.Rect rect, Thickness thickness)
+            => rect.Deflate(thickness.Left, thickness.Top, thickness.Right, thickness.Bottom);
+        public static SDL.Rect Inflate(this SDL.Rect rect, Thickness thickness)
+            => rect.Inflate(thickness.Left, thickness.Top, thickness.Right, thickness.Bottom);
+
+        public static SDL.Rect Deflate(this SDL.Rect rect, Size size)
+            => rect.Deflate(size.Width / 2f, size.Height / 2f, size.Width / 2f, size.Height / 2f);
+        public static SDL.Rect Inflate(this SDL.Rect rect, Size size)
+            => rect.Inflate(size.Width / 2f, size.Height / 2f, size.Width / 2f, size.Height / 2f);
+
+        public static string ToStr(this SDL.Rect rect, string? format = null)
+            => $"({rect.X},{rect.Y},{rect.W},{rect.H}){(format != null ? $":{format}" : "")}";
+    }
+
+    public static class RectNullable
+    {
+        public static SDL.Rect? ToRect(this SDL.FRect? rect)
+            => rect.HasValue ? rect.Value.ToRect() : null;
+
+        public static SDL.Rect? Offset(this SDL.Rect? rect, float dx, float dy)
+            => rect.HasValue ? rect.Value.Offset(dx, dy) : null;
+        public static SDL.Rect? Deflate(this SDL.Rect? rect, float left, float top, float right, float bottom)
+            => rect.HasValue ? rect.Value.Deflate(left, top, right, bottom) : null;
+        public static SDL.Rect? Inflate(this SDL.Rect? rect, float left, float top, float right, float bottom)
+            => rect.HasValue ? rect.Value.Inflate(left, top, right, bottom) : null;
+
+        public static SDL.Rect? Offset(this SDL.Rect? rect, Size size)
+            => rect.Offset(size.Width, size.Height);
+        public static SDL.Rect? Deflate(this SDL.Rect? rect, Thickness thickness)
+            => rect.Deflate(thickness.Left, thickness.Top, thickness.Right, thickness.Bottom);
+        public static SDL.Rect? Inflate(this SDL.Rect? rect, Thickness thickness)
+            => rect.Inflate(thickness.Left, thickness.Top, thickness.Right, thickness.Bottom);
+
+        public static SDL.Rect? Deflate(this SDL.Rect? rect, Size size)
+            => rect.Deflate(size.Width / 2f, size.Height / 2f, size.Width / 2f, size.Height / 2f);
+        public static SDL.Rect? Inflate(this SDL.Rect? rect, Size size)
+            => rect.Inflate(size.Width / 2f, size.Height / 2f, size.Width / 2f, size.Height / 2f);
+
+        public static string ToStr(this SDL.Rect? rect, string? format = null)
+            => rect.HasValue ? rect.Value.ToStr(format) : "null";
+    }
+
+    public static class FRect
+    {
+        public static SDL.Rect ToRect(this SDL.FRect rect)
+            => new()
+            {
+                X = (int)rect.X,
+                Y = (int)rect.Y,
+                W = (int)rect.W,
+                H = (int)rect.H
+            };
+
+        public static SDL.FRect Offset(this SDL.FRect rect, float dx, float dy)
+            => new() { X = rect.X + dx, Y = rect.Y + dy, W = rect.W, H = rect.H };
+        public static SDL.FRect Deflate(this SDL.FRect rect, float left, float top, float right, float bottom)
+            => new()
+            {
+                X = rect.X + left,
+                Y = rect.Y + top,
+                W = rect.W - (left + right),
+                H = rect.H - (top + bottom)
+            };
+        public static SDL.FRect Inflate(this SDL.FRect rect, float left, float top, float right, float bottom)
+            => rect.Deflate(-left, -top, -right, -bottom);
+
+        public static SDL.FRect Offset(this SDL.FRect rect, Size size)
+            => rect.Offset(size.Width, size.Height);
+        public static SDL.FRect Deflate(this SDL.FRect rect, Thickness thickness)
+            => rect.Deflate(thickness.Left, thickness.Top, thickness.Right, thickness.Bottom);
+        public static SDL.FRect Inflate(this SDL.FRect rect, Thickness thickness)
+            => rect.Inflate(thickness.Left, thickness.Top, thickness.Right, thickness.Bottom);
+
+        public static SDL.FRect Deflate(this SDL.FRect rect, Size size)
+            => rect.Deflate(size.Width / 2f, size.Height / 2f, size.Width / 2f, size.Height / 2f);
+        public static SDL.FRect Inflate(this SDL.FRect rect, Size size)
+            => rect.Inflate(size.Width / 2f, size.Height / 2f, size.Width / 2f, size.Height / 2f);
+
+        public static string ToStr(this SDL.FRect rect, string? format = null)
+            => $"({rect.X:F1},{rect.Y:F1},{rect.W:F1},{rect.H:F1}){(format != null ? $":{format}" : "")}";
+    }
+
+    public static class FRectNullable
+    {
+        public static SDL.FRect? Offset(this SDL.FRect? rect, float dx, float dy)
+            => rect.HasValue ? rect.Value.Offset(dx, dy) : null;
+        public static SDL.FRect? Deflate(this SDL.FRect? rect, float left, float top, float right, float bottom)
+            => rect.HasValue ? rect.Value.Deflate(left, top, right, bottom) : null;
+        public static SDL.FRect? Inflate(this SDL.FRect? rect, float left, float top, float right, float bottom)
+            => rect.HasValue ? rect.Value.Inflate(left, top, right, bottom) : null;
+
+        public static SDL.FRect? Offset(this SDL.FRect? rect, Size size)
+            => rect.Offset(size.Width, size.Height);
+        public static SDL.FRect? Deflate(this SDL.FRect? rect, Thickness thickness)
+            => rect.Deflate(thickness.Left, thickness.Top, thickness.Right, thickness.Bottom);
+        public static SDL.FRect? Inflate(this SDL.FRect? rect, Thickness thickness)
+            => rect.Inflate(thickness.Left, thickness.Top, thickness.Right, thickness.Bottom);
+
+        public static SDL.FRect? Deflate(this SDL.FRect? rect, Size size)
+            => rect.Deflate(size.Width / 2f, size.Height / 2f, size.Width / 2f, size.Height / 2f);
+        public static SDL.FRect? Inflate(this SDL.FRect? rect, Size size)
+            => rect.Inflate(size.Width / 2f, size.Height / 2f, size.Width / 2f, size.Height / 2f);
+
+        public static string ToStr(this SDL.FRect? rect, string? format = null)
+            => rect.HasValue ? rect.Value.ToStr(format) : "null";
+    }
+}

--- a/PhotonUI/Photon.cs
+++ b/PhotonUI/Photon.cs
@@ -1,0 +1,182 @@
+﻿using PhotonUI.Controls;
+using PhotonUI.Extensions;
+using PhotonUI.Models;
+using PhotonUI.Models.Properties;
+using SDL3;
+
+namespace PhotonUI
+{
+    public static class Photon
+    {
+        public static void EnsureRootWindow(Control control)
+        {
+            ArgumentNullException.ThrowIfNull(control);
+
+            if (control.Window is null)
+                throw new InvalidOperationException($"Control '{control.Name}' has no RootWindow.");
+        }
+        public static void InvalidateRenderChain(Control control)
+        {
+            if (!control.IsInitialized) return;
+
+            Control? boundary = null;
+
+            control.Parent?.BubbleControls(ancestor =>
+            {
+                ancestor.IsRenderDirty = true;
+
+                if (ancestor.IsVisible && ancestor.IsOpaque)
+                {
+                    boundary = ancestor;
+                    return false;
+                }
+                return true;
+            });
+
+            boundary ??= control.Window;
+
+            if (boundary?.Window != null)
+            {
+                boundary.RequestRender(false);
+                boundary.IsBoundryDirty = true;
+            }
+        }
+
+        #region Photon: Hit Testing
+
+        public static List<Control> GetControlPath(Control root, Func<Control, bool> predicate)
+        {
+            List<Control> path = [];
+
+            root.TunnelControls(control =>
+            {
+                bool value = predicate(control);
+
+                path.Add(control);
+
+                if (value == true)
+                    return false;
+                return true;
+
+            }, TunnelDirection.TopDown);
+
+            return path;
+        }
+
+        #endregion
+
+        #region Photon: Layout Helpers
+
+        public static Size GetMinimumSize(Control control, Size? childSize = null)
+        {
+            float coreWidth = childSize?.Width ?? control.MinWidth;
+            float coreHeight = childSize?.Height ?? control.MinHeight;
+
+            float effectiveWidth = Math.Clamp(coreWidth, control.MinWidth, control.MaxWidth);
+            float effectiveHeight = Math.Clamp(coreHeight, control.MinHeight, control.MaxHeight);
+
+            float width = effectiveWidth + control.PaddingExtent.Horizontal;
+            float height = effectiveHeight + control.PaddingExtent.Vertical;
+
+            return new Size { Width = width, Height = height };
+        }
+
+        #endregion
+
+        #region Photon: Clip Management Helpers
+
+        public static void GetControlClipRect(SDL.FRect controlRect, bool clipToBounds, SDL.Rect? clipRect, out SDL.Rect? rect)
+        {
+            if (!clipToBounds)
+            {
+                rect = clipRect;
+                return;
+            }
+
+            if (clipRect.HasValue)
+            {
+                if (SDL.GetRectIntersection(controlRect.ToRect(), clipRect.Value, out SDL.Rect newClipRect))
+                {
+                    rect = newClipRect;
+
+                    return;
+                }
+                else
+                {
+                    rect = null;
+
+                    return;
+                }
+            }
+
+            rect = controlRect.ToRect();
+        }
+        public static void ApplyControlClipRect(Window window, SDL.Rect? intersection)
+        {
+            IntPtr previousTarget = SDL.GetRenderTarget(window.Renderer);
+
+            if (window.BackTexture != IntPtr.Zero)
+                SDL.SetRenderTarget(window.Renderer, window.BackTexture);
+
+            if (intersection.HasValue)
+                SDL.SetRenderClipRect(window.Renderer, intersection.Value);
+            else
+                SDL.SetRenderClipRect(window.Renderer, IntPtr.Zero);
+
+            SDL.SetRenderTarget(window.Renderer, previousTarget);
+        }
+
+        #endregion
+
+        #region Photon: Drawing Helpers
+
+        public static void DrawRectangle(Window window, SDL.FRect rect, SDL.Color color, IntPtr target)
+        {
+            if (color.A < 1) return;
+
+            IntPtr previousTarget = SDL.GetRenderTarget(window.Renderer);
+
+            if (target != IntPtr.Zero)
+                SDL.SetRenderTarget(window.Renderer, target);
+
+            SDL.GetRenderDrawBlendMode(window.Renderer, out SDL.BlendMode previousBlendMode);
+
+            SDL.SetRenderDrawBlendMode(window.Renderer, SDL.BlendMode.Blend);
+
+            if (color.A > 0)
+            {
+                SDL.SetRenderDrawColor(window.Renderer, color.R, color.G, color.B, color.A);
+
+                SDL.RenderFillRect(window.Renderer, rect);
+            }
+
+            SDL.SetRenderDrawBlendMode(window.Renderer, previousBlendMode);
+
+            if (target != IntPtr.Zero)
+                SDL.SetRenderTarget(window.Renderer, previousTarget);
+        }
+
+        #endregion
+
+        #region Photon: Control Drawing Helpers
+
+        public static void DrawControlBackground<T>(T control) where T : Control, IControlProperties
+        {
+            EnsureRootWindow(control);
+
+            SDL.Color adjusted = new()
+            {
+                R = control.BackgroundColor.R,
+                G = control.BackgroundColor.G,
+                B = control.BackgroundColor.B,
+                A = (byte)(control.BackgroundColor.A * control.Opacity)
+            };
+
+            SDL.FRect drawSurface = control.DrawRect;
+
+            DrawRectangle(control.Window!, drawSurface, adjusted, control.Window?.BackTexture ?? default);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Description
This change introduces a structured rendering lifecycle for controls, formalizing the execution phase.

Key additions include:
- Introduction of an Intrinsic phase with segmented dirty-state handling (`IsIntrinsicDirty`).
- Separation of intrinsic, layout, and render invalidation flags.
- Render invalidation propagation with opaque boundary detection.
- Default `FrameworkRender` implementation including clip calculation and background rendering.
- Geometry helper extensions (`Rect` / `FRect`) to support layout and render math.
- Framework-level event bubbling via `ChildPropertyChangedEventArgs`.
- Render chain invalidation utilities and clip management helpers.

This establishes the architectural foundation required for a scalable and optimizable render engine without introducing breaking API changes.

## Related Issue
- Resolves #23

## Motivation and Context
The framework previously lacked a formally defined rendering lifecycle and segmented invalidation model. This change provides deterministic lifecycle ordering and structured dirty-state tracking, enabling partial layout recalculation, render boundary optimization, and future rendering engine enhancements.

This milestone transitions the system from loosely coordinated control behavior to a governed rendering pipeline.

## How Has This Been Tested?
- Confirmed compilation

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.
