### PR TITLE
Adding Mouse and Keyboard Capture Support

### DIFF
--- a/PhotonUI/Events/Framework/KeyboardCaptured.cs
+++ b/PhotonUI/Events/Framework/KeyboardCaptured.cs
@@ -1,0 +1,11 @@
+﻿using PhotonUI.Controls;
+
+namespace PhotonUI.Events.Framework
+{
+    public class KeyboardCaptured(Window window, Control captured)
+        : FrameworkEventArgs
+    {
+        public Window Window = window;
+        public Control Captured = captured;
+    }
+}

--- a/PhotonUI/Events/Framework/KeyboardReleased.cs
+++ b/PhotonUI/Events/Framework/KeyboardReleased.cs
@@ -1,0 +1,11 @@
+﻿using PhotonUI.Controls;
+
+namespace PhotonUI.Events.Framework
+{
+    public class KeyboardReleased(Window window, Control released)
+        : FrameworkEventArgs
+    {
+        public Window Window = window;
+        public Control Released = released;
+    }
+}

--- a/PhotonUI/Events/Framework/MouseCaptured.cs
+++ b/PhotonUI/Events/Framework/MouseCaptured.cs
@@ -1,0 +1,11 @@
+﻿using PhotonUI.Controls;
+
+namespace PhotonUI.Events.Framework
+{
+    public class MouseCaptured(Window window, Control captured)
+        : FrameworkEventArgs
+    {
+        public Window Window = window;
+        public Control Captured = captured;
+    }
+}

--- a/PhotonUI/Events/Framework/MouseReleased.cs
+++ b/PhotonUI/Events/Framework/MouseReleased.cs
@@ -1,0 +1,11 @@
+﻿using PhotonUI.Controls;
+
+namespace PhotonUI.Events.Framework
+{
+    public class MouseReleased(Window window, Control released)
+        : FrameworkEventArgs
+    {
+        public Window Window = window;
+        public Control Released = released;
+    }
+}

--- a/PhotonUI/Events/Platform/MouseClickEventArgs.cs
+++ b/PhotonUI/Events/Platform/MouseClickEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using PhotonUI.Controls;
+using SDL3;
+
+namespace PhotonUI.Events.Platform
+{
+    public class MouseClickEventArgs(Window window, Control clicked, SDL.Event e)
+        : PlatformEventArgs(e)
+    {
+        public Window Window = window;
+        public Control Clicked = clicked;
+    }
+}

--- a/PhotonUI/Events/Platform/MouseEnterEventArgs.cs
+++ b/PhotonUI/Events/Platform/MouseEnterEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using PhotonUI.Controls;
+using SDL3;
+
+namespace PhotonUI.Events.Platform
+{
+    public class MouseEnterEventArgs(Window window, Control entered, SDL.Event e)
+        : PlatformEventArgs(e)
+    {
+        public Window Window = window;
+        public Control Entered = entered;
+    }
+}

--- a/PhotonUI/Events/Platform/MouseExitEventArgs.cs
+++ b/PhotonUI/Events/Platform/MouseExitEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using PhotonUI.Controls;
+using SDL3;
+
+namespace PhotonUI.Events.Platform
+{
+    public class MouseExitEventArgs(Window window, Control exited, SDL.Event e)
+        : PlatformEventArgs(e)
+    {
+        public Window Window = window;
+        public Control Exited = exited;
+    }
+}

--- a/PhotonUI/Events/Platform/MouseWheelEventArgs.cs
+++ b/PhotonUI/Events/Platform/MouseWheelEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using PhotonUI.Controls;
+using SDL3;
+
+namespace PhotonUI.Events.Platform
+{
+    public class MouseWheelEventArgs(Window window, Control wheeled, SDL.Event e)
+        : PlatformEventArgs(e)
+    {
+        public Window Window = window;
+        public Control Wheeled = wheeled;
+    }
+}


### PR DESCRIPTION
## Description

This pull request introduces explicit mouse and keyboard capture support to the `Window` input system.

Controls can now request exclusive device ownership through `CaptureMouse` / `ReleaseMouse` and `CaptureKeyboard` / `ReleaseKeyboard`. When capture is active:

* Mouse click and wheel events are routed to the captured control regardless of pointer location.
* Keyboard input is routed to the captured control before the focused control.

To support this behavior, hit-testing utilities were added to resolve the control under the pointer when no capture is active. Basic hover tracking was implemented, including mouse enter and exit event dispatch when the hover path changes.

Mouse input now supports preview and bubble routing phases. Additionally, the following framework events were introduced:

* `MouseCaptured`
* `MouseReleased`
* `KeyboardCaptured`
* `KeyboardReleased`

When no capture is active, mouse routing continues to rely on hit testing as the default behavior.

## Related Issue

- Resolves #25

## Motivation and Context

Certain interactions (such as drag operations or temporary keyboard ownership) require a control to retain input ownership beyond normal hit-testing or focus rules.

This change enables controls to explicitly capture mouse or keyboard input, ensuring consistent and predictable event routing during extended interactions. It establishes foundational input infrastructure for more advanced control behaviors.

## How Has This Been Tested?

* Verified that the solution compiles

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Asset change (adds or updates icons, templates, or other assets)
* [ ] Documentation change (adds or updates documentation)
* [ ] Plugin change (adds or updates a plugin)

## Checklist:

* [x] I have read the **CONTRIBUTING** document.
* [x] My change requires a change to the core logic.
  * [x] I have linked the project issue above.
* [ ] My change requires a change to the assets.
  * [ ] I have linked the asset issue above.
* [ ] My change requires a change to the documentation.
  * [ ] I have linked the documentation issue above.
* [ ] My change requires a change to a plugin.
  * [ ] I have linked the plugin issue above.
