### PR TITLE
Adding Control Mouse Event Action Hooks

### DIFF
--- a/PhotonUI/Controls/Control.cs
+++ b/PhotonUI/Controls/Control.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using PhotonUI.Events;
 using PhotonUI.Events.Framework;
+using PhotonUI.Events.Platform;
 using PhotonUI.Exceptions;
 using PhotonUI.Interfaces;
 using PhotonUI.Models;
@@ -82,6 +83,12 @@ namespace PhotonUI.Controls
 
         public Action<FocusGainedEventArgs>? FocusGainedAction { get; set; }
         public Action<FocusLostEventArgs>? FocusLostAction { get; set; }
+
+        public Action<MouseEnterEventArgs>? MouseEnterAction { get; set; }
+        public Action<MouseExitEventArgs>? MouseExitAction { get; set; }
+
+        public Action<MouseClickEventArgs>? MouseClickAction { get; set; }
+        public Action<MouseWheelEventArgs>? MouseWheelAction { get; set; }
 
         #endregion
 
@@ -481,6 +488,22 @@ namespace PhotonUI.Controls
                 case FocusLostEventArgs focusLost:
                     this.IsFocused = false;
                     this.FocusLostAction?.Invoke(focusLost);
+                    break;
+
+                case MouseEnterEventArgs mouseEnter:
+                    this.MouseEnterAction?.Invoke(mouseEnter);
+                    break;
+
+                case MouseExitEventArgs mouseExit:
+                    this.MouseExitAction?.Invoke(mouseExit);
+                    break;
+
+                case MouseClickEventArgs mouseClick:
+                    this.MouseClickAction?.Invoke(mouseClick);
+                    break;
+
+                case MouseWheelEventArgs mouseWheel:
+                    this.MouseWheelAction?.Invoke(mouseWheel);
                     break;
             }
         }


### PR DESCRIPTION
## Description

This pull request adds direct action delegate properties to the `Control` base class for handling mouse-related events. The following new properties were introduced:

* `MouseEnterAction`
* `MouseExitAction`
* `MouseClickAction`
* `MouseWheelAction`

These actions are invoked automatically when the corresponding mouse event arguments are dispatched to the control. This allows developers to handle mouse interactions without subclassing or additional event wiring. Existing focus-related behaviors remain unchanged.

## Related Issue

- Resolves #27

## Motivation and Context

Control developers often need to respond to mouse interactions. Previously, this required either subclassing controls or manually subscribing to framework events. By adding dedicated action hooks, developers can now attach handlers directly to control instances, improving usability, consistency, and code readability.

## How Has This Been Tested?

* Confirmed that the project builds successfully.

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Asset change (adds or updates icons, templates, or other assets)
* [ ] Documentation change (adds or updates documentation)
* [ ] Plugin change (adds or updates a plugin)

## Checklist:

* [x] I have read the **CONTRIBUTING** document.
* [x] My change requires a change to the core logic.
  * [x] I have linked the project issue above.
* [ ] My change requires a change to the assets.
  * [ ] I have linked the asset issue above.
* [ ] My change requires a change to the documentation.
  * [ ] I have linked the documentation issue above.
* [ ] My change requires a change to a plugin.
  * [ ] I have linked the plugin issue above.