### PR TITLE
Adding Presenter Stretch and Layout Support 

### DIFF
--- a/PhotonUI/Controls/Presenter.cs
+++ b/PhotonUI/Controls/Presenter.cs
@@ -1,4 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Extensions;
+using PhotonUI.Models;
+using SDL3;
 
 namespace PhotonUI.Controls
 {
@@ -27,6 +30,8 @@ namespace PhotonUI.Controls
                 {
                     if (Window == null)
                         throw new InvalidOperationException($"Control '{value.Name}' is not associated with a RootWindow.");
+
+                    value.FrameworkInitialize(Window);
                 }
             }
         }
@@ -47,6 +52,117 @@ namespace PhotonUI.Controls
             }
 
             return true;
+        }
+
+        public override void FrameworkIntrinsic(Window window, Size content)
+        {
+            Size? childSize = null;
+
+            if (this.Child != null)
+            {
+                // Adjust content size for child's margins and padding
+                Size childContent = content.Deflate(this.Child.MarginExtent).Deflate(this.Child.PaddingExtent);
+
+                // Get the child's intrinsic size
+                this.Child.OnIntrinsic(window, childContent);
+
+                childSize = this.Child.IntrinsicSize;
+            }
+
+            // Calculate the intrinsic size, but only if not a Window (for base controls)
+            if (this.GetType() != typeof(Window))
+                this.IntrinsicSize = Photon.GetMinimumSize(this, childSize);
+        }
+        public override void FrameworkMeasure(Window window)
+        {
+            if (this.Child != null)
+            {
+                // Get available space for child after padding
+                SDL.FRect containerRect = this.DrawRect.Deflate(this.PaddingExtent);
+
+                // Stretch within remaining space after total offsets (X + margins)
+                float stretchedW = Photon.GetStretchedWidth(
+                    this.Child.HorizontalAlignment,
+                    this.Child.IntrinsicSize.Width,
+                    containerRect.W,
+                    this.Child.X + this.Child.MarginExtent.Horizontal);
+
+                float stretchedH = Photon.GetStretchedHeight(
+                    this.Child.VerticalAlignment,
+                    this.Child.IntrinsicSize.Height,
+                    containerRect.H,
+                    this.Child.Y + this.Child.MarginExtent.Vertical);
+
+                // Set child's content size within min/max bounds
+                this.Child.DrawRect.W = Math.Clamp(stretchedW, this.Child.MinWidth, this.Child.MaxWidth);
+                this.Child.DrawRect.H = Math.Clamp(stretchedH, this.Child.MinHeight, this.Child.MaxHeight);
+            }
+        }
+        public override void FrameworkArrange(Window window, SDL.FPoint anchor)
+        {
+            // Set position based on anchor and margins
+            this.DrawRect.X = anchor.X + this.MarginExtent.Left + this.X;
+            this.DrawRect.Y = anchor.Y + this.MarginExtent.Top + this.Y;
+
+            if (this.Child != null)
+            {
+                // Adjust child's position by padding
+                float childX = this.DrawRect.X + this.PaddingExtent.Left;
+                float childY = this.DrawRect.Y + this.PaddingExtent.Top;
+
+                // Calculate horizontal alignment position for child
+                float horizontalPosition =
+                    Photon.GetHorizontalAlignment(
+                        this.Child.HorizontalAlignment,
+                        childX,
+                        this.Child.DrawRect.W,
+                        this.DrawRect.W);
+
+                // Calculate vertical alignment position for child
+                float verticalPosition =
+                    Photon.GetVerticalAlignment(
+                        this.Child.VerticalAlignment,
+                        childY,
+                        this.Child.DrawRect.H,
+                        this.DrawRect.H);
+
+                // Define final anchor point for child
+                SDL.FPoint childAnchor = new() { X = horizontalPosition, Y = verticalPosition };
+
+                // Arrange child based on computed anchor point
+                this.Child.OnArrange(window, childAnchor);
+            }
+        }
+        public override void FrameworkRender(Window window, SDL.Rect? clipRect)
+        {
+            // Skip rendering if control is not visible
+            if (this.IsVisible)
+            {
+                // Get the effective clipping rectangle by intersecting with parent's clip rect
+                Photon.GetControlClipRect(this.DrawRect, this.ClipToBounds, clipRect, out SDL.Rect? effectiveClipRect);
+
+                // Only render if the control is within the clip bounds or unclipped
+                if (effectiveClipRect.HasValue)
+                {
+                    // Apply the effective clipping region
+                    Photon.ApplyControlClipRect(window, effectiveClipRect);
+
+                    // Draw the control's background
+                    Photon.DrawControlBackground(this);
+
+                    if (this.Child != null)
+                    {
+                        // Calculate the child's clipping region within the parent bounds
+                        SDL.Rect? childClipRect = effectiveClipRect.Deflate(this.PaddingExtent);
+
+                        // Render the child with its clip region
+                        this.Child.OnRender(window, childClipRect);
+                    }
+
+                    // Restore the original clip region
+                    Photon.ApplyControlClipRect(window, clipRect);
+                }
+            }
         }
 
         #endregion

--- a/PhotonUI/Models/Properties/StretchProperties.cs
+++ b/PhotonUI/Models/Properties/StretchProperties.cs
@@ -1,0 +1,35 @@
+﻿using PhotonUI.Interfaces;
+
+namespace PhotonUI.Models.Properties
+{
+    public enum StretchMode
+    {
+        None,
+        Fill,
+        Uniform,
+        UniformToFill
+    }
+
+    public enum StretchDirection
+    {
+        UpOnly,
+        DownOnly,
+        Both
+    }
+
+    public interface IStretchProperties : IStyleProperties
+    {
+        StretchMode StretchMode { get; }
+        StretchDirection StretchDirection { get; }
+    }
+
+    public readonly record struct StretchProperties(
+        StretchMode StretchMode,
+        StretchDirection StretchDirection) : IStretchProperties
+    {
+        public static StretchProperties Default => new(
+            StretchMode.None,
+            StretchDirection.Both
+        );
+    }
+}

--- a/PhotonUI/Photon.cs
+++ b/PhotonUI/Photon.cs
@@ -168,6 +168,54 @@ namespace PhotonUI
             return new Size { Width = width, Height = height };
         }
 
+        public static float GetStretchedWidth(HorizontalAlignment alignment, float width, float available, float offsetX = 0)
+        {
+            if (alignment != HorizontalAlignment.Stretch)
+                return width;
+
+            float usable = available - offsetX;
+            if (usable >= width)
+                return usable;
+
+            return width;
+        }
+        public static float GetStretchedHeight(VerticalAlignment alignment, float height, float available, float offsetY = 0)
+        {
+            if (alignment != VerticalAlignment.Stretch)
+                return height;
+
+            float usable = available - offsetY;
+            if (usable >= height)
+                return usable;
+
+            return height;
+        }
+
+        public static float GetHorizontalAlignment(HorizontalAlignment alignment, float intial, float width, float availableWidth)
+        {
+            switch (alignment)
+            {
+                case HorizontalAlignment.Center:
+                    return intial + (availableWidth - width) / 2;
+                case HorizontalAlignment.Right:
+                    return intial + (availableWidth - width);
+                default:
+                    return intial;
+            }
+        }
+        public static float GetVerticalAlignment(VerticalAlignment alignment, float intial, float height, float availableHeight)
+        {
+            switch (alignment)
+            {
+                case VerticalAlignment.Center:
+                    return intial + (availableHeight - height) / 2;
+                case VerticalAlignment.Bottom:
+                    return intial + (availableHeight - height);
+                default:
+                    return intial;
+            }
+        }
+
         #endregion
 
         #region Photon: Clip Management Helpers


### PR DESCRIPTION
## Description

This pull request introduces a full stretching and layout system for the `Presenter` control in the PhotonUI framework.

Changes include:

* New `StretchProperties` system (`StretchMode`, `StretchDirection`, and `IStretchProperties`) for flexible content resizing.
* Updates to the `Presenter` control with intrinsic, measure, arrange, and render logic that respects stretch, alignment, padding, and clipping.
* Helper methods added to `Photon` for calculating stretched dimensions and alignment positions (`GetStretchedWidth`, `GetStretchedHeight`, `GetHorizontalAlignment`, `GetVerticalAlignment`).
* Automatic framework initialization of child controls to ensure correct layout behavior.

This allows controls hosted in a `Presenter` to stretch and align dynamically based on container size, improving layout flexibility and visual consistency.

## Related Issue

- Resolves #31

## Motivation and Context

Previously, the `Presenter` did not properly handle stretching, alignment, or dynamic layout calculations for child controls. This change provides a robust system for responsive layouts, ensuring child controls adapt to container size and alignment preferences automatically.

## How Has This Been Tested?

* Confirmed that the project builds successfully.

## Screenshots (if appropriate):

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Asset change (adds or updates icons, templates, or other assets)
* [ ] Documentation change (adds or updates documentation)
* [ ] Plugin change (adds or updates a plugin)

## Checklist:

* [x] I have read the **CONTRIBUTING** document.
* [x] My change requires a change to the core logic.
  * [x] I have linked the project issue above.
* [ ] My change requires a change to the assets.
  * [ ] I have linked the asset issue above.
* [ ] My change requires a change to the documentation.
  * [ ] I have linked the documentation issue above.
* [ ] My change requires a change to a plugin.
  * [ ] I have linked the plugin issue above.