### PR TITLE
Adding Binding Service for Property Synchronization

### DIFF
--- a/PhotonUI/Components/PropertyBinder.cs
+++ b/PhotonUI/Components/PropertyBinder.cs
@@ -1,0 +1,71 @@
+﻿using PhotonUI.Controls;
+using System.ComponentModel;
+
+namespace PhotonUI.Components
+{
+    public class PropertyBinder
+    {
+        public readonly Control Target;
+        public readonly string TargetProperty;
+        public readonly object Source;
+        public readonly string SourceProperty;
+        public readonly bool TwoWay;
+
+        private readonly Func<object, object?> sourceGetter;
+        private readonly Action<object, object?>? sourceSetter;
+        private readonly Func<object, object?> targetGetter;
+        private readonly Action<object, object?>? targetSetter;
+
+        public PropertyBinder(
+            Control target, string targetProperty, object source, string sourceProperty,
+            Func<object, object?> sourceGetter, Action<object, object?>? sourceSetter,
+            Func<object, object?> targetGetter, Action<object, object?>? targetSetter,
+            bool twoWay = false)
+        {
+            this.Target = target;
+            this.TargetProperty = targetProperty;
+            this.Source = source;
+            this.SourceProperty = sourceProperty;
+            this.TwoWay = twoWay;
+
+            this.sourceGetter = sourceGetter;
+            this.sourceSetter = sourceSetter;
+            this.targetGetter = targetGetter;
+            this.targetSetter = targetSetter;
+
+            this.UpdateTarget();
+
+            if (this.Source is INotifyPropertyChanged npcSource)
+            {
+                npcSource.PropertyChanged += (sender, args) =>
+                {
+                    if (args.PropertyName == this.SourceProperty)
+                        this.UpdateTarget();
+                };
+            }
+
+            if (this.TwoWay && this.Target is INotifyPropertyChanged npcTarget)
+            {
+                npcTarget.PropertyChanged += (sender, args) =>
+                {
+                    if (args.PropertyName == this.TargetProperty)
+                        this.UpdateSource();
+                };
+            }
+        }
+
+        private void UpdateTarget()
+        {
+            object? value = this.sourceGetter(this.Source);
+
+            this.targetSetter?.Invoke(this.Target, value);
+        }
+
+        private void UpdateSource()
+        {
+            object? value = this.targetGetter(this.Target);
+
+            this.sourceSetter?.Invoke(this.Source, value);
+        }
+    }
+}

--- a/PhotonUI/Controls/Presenter.cs
+++ b/PhotonUI/Controls/Presenter.cs
@@ -1,12 +1,13 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using PhotonUI.Extensions;
+using PhotonUI.Interfaces.Services;
 using PhotonUI.Models;
 using SDL3;
 
 namespace PhotonUI.Controls
 {
-    public partial class Presenter(IServiceProvider serviceProvider)
-        : Control(serviceProvider)
+    public partial class Presenter(IServiceProvider serviceProvider, IBindingService bindingService)
+        : Control(serviceProvider, bindingService)
     {
         [ObservableProperty] private Control? child;
 

--- a/PhotonUI/Controls/Window.cs
+++ b/PhotonUI/Controls/Window.cs
@@ -2,14 +2,15 @@
 using PhotonUI.Events.Framework;
 using PhotonUI.Events.Platform;
 using PhotonUI.Extensions;
+using PhotonUI.Interfaces.Services;
 using SDL3;
 
 namespace PhotonUI.Controls
 {
     public record WindowTabStopEntry(int Stop, Control Control, int InsertionOrder);
 
-    public partial class Window(IServiceProvider serviceProvider)
-        : Presenter(serviceProvider)
+    public partial class Window(IServiceProvider serviceProvider, IBindingService bindingService)
+        : Presenter(serviceProvider, bindingService)
     {
         protected IntPtr WindowBackTexture;
 

--- a/PhotonUI/Extensions/DependencyInjection.cs
+++ b/PhotonUI/Extensions/DependencyInjection.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace PhotonUI.Extensions
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static T Create<T>(IServiceProvider provider, params object[] args)
+            where T : class
+        {
+            T? resolved = provider.GetService<T>();
+
+            if (resolved != null)
+                return resolved;
+
+            try
+            {
+                return ActivatorUtilities.CreateInstance<T>(provider, args);
+            }
+            catch
+            {
+                return (T)Activator.CreateInstance(typeof(T), args)!;
+            }
+        }
+    }
+}

--- a/PhotonUI/Interfaces/Services/IBindingService.cs
+++ b/PhotonUI/Interfaces/Services/IBindingService.cs
@@ -1,0 +1,10 @@
+﻿using PhotonUI.Controls;
+
+namespace PhotonUI.Interfaces.Services
+{
+    public interface IBindingService
+    {
+        void Bind(Control target, string targetProperty, object source, string sourceProperty, bool twoWay = false);
+        void Unbind(Control target, string targetProperty);
+    }
+}

--- a/PhotonUI/Services/BindingService.cs
+++ b/PhotonUI/Services/BindingService.cs
@@ -1,0 +1,58 @@
+﻿using PhotonUI.Components;
+using PhotonUI.Controls;
+using PhotonUI.Interfaces.Services;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace PhotonUI.Services
+{
+    public class BindingService : IBindingService
+    {
+        private readonly List<PropertyBinder> bindings = [];
+
+        private static Func<object, object?> BuildGetter(PropertyInfo prop)
+        {
+            ParameterExpression objParam = Expression.Parameter(typeof(object), "obj");
+            UnaryExpression castObj = Expression.Convert(objParam, prop.DeclaringType!);
+            MemberExpression propAccess = Expression.Property(castObj, prop);
+            UnaryExpression castResult = Expression.Convert(propAccess, typeof(object));
+
+            return Expression.Lambda<Func<object, object?>>(castResult, objParam).Compile();
+        }
+        private static Action<object, object?>? BuildSetter(PropertyInfo prop)
+        {
+            if (!prop.CanWrite)
+                return null;
+
+            ParameterExpression objParam = Expression.Parameter(typeof(object), "obj");
+            ParameterExpression valParam = Expression.Parameter(typeof(object), "val");
+
+            UnaryExpression castObj = Expression.Convert(objParam, prop.DeclaringType!);
+            UnaryExpression castVal = Expression.Convert(valParam, prop.PropertyType);
+
+            MethodCallExpression call = Expression.Call(castObj, prop.SetMethod!, castVal);
+
+            return Expression.Lambda<Action<object, object?>>(call, objParam, valParam).Compile();
+        }
+
+        public void Bind(Control target, string targetProperty, object source, string sourceProperty, bool twoWay = false)
+        {
+            PropertyInfo? sourceProp = source.GetType().GetProperty(sourceProperty, BindingFlags.Public | BindingFlags.Instance);
+            PropertyInfo? targetProp = target.GetType().GetProperty(targetProperty, BindingFlags.Public | BindingFlags.Instance);
+
+            if (sourceProp == null || targetProp == null)
+                throw new InvalidOperationException($"Binding failed: property not found (source={sourceProperty}, target={targetProperty})");
+
+            Func<object, object?> sourceGetter = BuildGetter(sourceProp);
+            Action<object, object?>? sourceSetter = BuildSetter(sourceProp);
+            Func<object, object?> targetGetter = BuildGetter(targetProp);
+            Action<object, object?>? targetSetter = BuildSetter(targetProp);
+
+            PropertyBinder binding = new(target, targetProperty, source, sourceProperty, sourceGetter, sourceSetter, targetGetter, targetSetter, twoWay);
+
+            this.bindings.Add(binding);
+        }
+        public void Unbind(Control target, string targetProperty)
+            => this.bindings.RemoveAll(b => b.Target == target && b.TargetProperty == targetProperty);
+    }
+}


### PR DESCRIPTION
## Description

This pull request introduces a new `BindingService` to enable property binding between controls and arbitrary source objects.

The service supports:

* One-way binding from source to target.
* Optional two-way binding when setters are available.
* Dynamic getter and setter generation using expression trees for efficient property access.
* Unbinding of previously registered bindings.

The `BindingService` has been integrated into the `Control`, `Presenter`, and `Window` classes to allow binding usage throughout the core framework layer.

## Related Issue

- Resolves #33

## Motivation and Context

Manual synchronization between UI controls and backing data models leads to repetitive and error-prone code. Introducing a centralized binding service enables declarative property synchronization, improving maintainability and reducing boilerplate.

This provides foundational infrastructure for data-driven UI patterns within the framework.

## How Has This Been Tested?

* Confirmed that the project builds successfully.

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Asset change (adds or updates icons, templates, or other assets)
* [ ] Documentation change (adds or updates documentation)
* [ ] Plugin change (adds or updates a plugin)

## Checklist:

* [x] I have read the **CONTRIBUTING** document.
* [x] My change requires a change to the core logic.
  * [x] I have linked the project issue above.
* [ ] My change requires a change to the assets.
  * [ ] I have linked the asset issue above.
* [ ] My change requires a change to the documentation.
  * [ ] I have linked the documentation issue above.
* [ ] My change requires a change to a plugin.
  * [ ] I have linked the plugin issue above.
