### PR TITLE
Adding Border Decorator Control

### DIFF
--- a/PhotonUI/Controls/Decorators/Border.cs
+++ b/PhotonUI/Controls/Decorators/Border.cs
@@ -1,0 +1,107 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Interfaces;
+using PhotonUI.Interfaces.Services;
+using PhotonUI.Models;
+using PhotonUI.Models.Properties;
+using SDL3;
+using System.ComponentModel;
+
+namespace PhotonUI.Controls.Decorators
+{
+    public partial class Border(IServiceProvider serviceProvider, IBindingService bindingService)
+        : Presenter(serviceProvider, bindingService), IBorderProperties
+    {
+        [ObservableProperty] private BorderColors borderColors = BorderProperties.Default.BorderColors;
+        [ObservableProperty] private Thickness borderThickness = BorderProperties.Default.BorderThickness;
+
+        public override Thickness PaddingExtent
+            => this.Padding + this.BorderThickness;
+
+        #region Border: Framework
+
+        public override void ApplyStyles(params IStyleProperties[] properties)
+        {
+            this.ValidateStyles(properties);
+
+            base.ApplyStyles(properties);
+
+            foreach (IStyleProperties prop in properties)
+            {
+                switch (prop)
+                {
+                    case IBorderProperties props:
+                        this.ApplyProperties(props);
+                        break;
+                }
+            }
+        }
+
+        public override void FrameworkRender(Window window, SDL.Rect? clipRect)
+        {
+            // Skip rendering if control is not visible
+            if (!this.IsVisible) return;
+
+            // Calculate the effective clip region for the control
+            Photon.GetControlClipRect(this.DrawRect, this.ClipToBounds, clipRect, out SDL.Rect? effectiveClipRect);
+
+            // Only render if control intersects the viewport or is unclipped
+            if (effectiveClipRect.HasValue)
+            {
+                // Apply the effective clipping region
+                Photon.ApplyControlClipRect(window, effectiveClipRect);
+
+                // Draw the control's background
+                base.FrameworkRender(window, clipRect);
+
+                // Draw the control's border 
+                Photon.DrawControlBorder(this);
+
+                // Restore the original clip region
+                Photon.ApplyControlClipRect(window, clipRect);
+            }
+        }
+
+        #endregion
+
+        #region Border: Hooks
+
+        protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+        {
+            if (!this.IsInitialized)
+                return;
+
+            if (this.Window == null)
+                throw new InvalidOperationException($"Control '{this.Name}' is not associated to a RootWindow.");
+
+            base.OnPropertyChanged(e);
+
+            bool invalidateMeasure = false;
+            bool invalidateLayout = false;
+            bool invalidateRender = false;
+
+            switch (e.PropertyName)
+            {
+                case nameof(this.BorderThickness):
+                    invalidateMeasure = true;
+                    invalidateLayout = true;
+                    invalidateRender = true;
+                    break;
+
+                case nameof(this.BorderColors):
+                    invalidateRender = true;
+                    break;
+            }
+
+            if (invalidateMeasure)
+                this.Parent?.RequestMeasure();
+
+            if (invalidateLayout)
+                this.Parent?.RequestArrange();
+
+            if (invalidateRender)
+                this.RequestRender();
+        }
+
+        #endregion
+    }
+}

--- a/PhotonUI/Models/BorderColors.cs
+++ b/PhotonUI/Models/BorderColors.cs
@@ -1,0 +1,52 @@
+﻿using SDL3;
+
+namespace PhotonUI.Models
+{
+    public readonly struct BorderColors
+    {
+        public SDL.Color Top { get; }
+        public SDL.Color Right { get; }
+        public SDL.Color Bottom { get; }
+        public SDL.Color Left { get; }
+
+        public BorderColors(SDL.Color uniform)
+            : this(uniform, uniform, uniform, uniform) { }
+
+        public BorderColors(SDL.Color top, SDL.Color right, SDL.Color bottom, SDL.Color left)
+        {
+            this.Top = top;
+            this.Right = right;
+            this.Bottom = bottom;
+            this.Left = left;
+        }
+
+        public BorderColors(SDL.Color lr, SDL.Color tb)
+        {
+            this.Left = lr;
+            this.Right = lr;
+            this.Top = tb;
+            this.Bottom = tb;
+        }
+
+        public BorderColors WithOpacity(float opacity)
+        {
+            return new BorderColors(
+                AdjustAlpha(this.Top, opacity),
+                AdjustAlpha(this.Right, opacity),
+                AdjustAlpha(this.Bottom, opacity),
+                AdjustAlpha(this.Left, opacity)
+            );
+        }
+
+        private static SDL.Color AdjustAlpha(SDL.Color c, float opacity)
+        {
+            return new SDL.Color
+            {
+                R = c.R,
+                G = c.G,
+                B = c.B,
+                A = (byte)(c.A * opacity)
+            };
+        }
+    }
+}

--- a/PhotonUI/Models/Properties/BorderProperties.cs
+++ b/PhotonUI/Models/Properties/BorderProperties.cs
@@ -1,0 +1,21 @@
+﻿using PhotonUI.Interfaces;
+using SDL3;
+
+namespace PhotonUI.Models.Properties
+{
+    public interface IBorderProperties : IStyleProperties
+    {
+        BorderColors BorderColors { get; }
+        Thickness BorderThickness { get; }
+    }
+
+    public readonly record struct BorderProperties(
+        BorderColors BorderColors,
+        Thickness BorderThickness) : IBorderProperties
+    {
+        public static BorderProperties Default => new(
+            new BorderColors(new SDL.Color { R = 255, G = 255, B = 255, A = 255 }),
+            new Thickness(1)
+        );
+    }
+}

--- a/PhotonUI/Photon.cs
+++ b/PhotonUI/Photon.cs
@@ -308,6 +308,64 @@ namespace PhotonUI
             if (target != IntPtr.Zero)
                 SDL.SetRenderTarget(window.Renderer, previousTarget);
         }
+        public static void DrawBorder(Window window, SDL.FRect controlRect, Thickness borderThickness, BorderColors colors, IntPtr target)
+        {
+            IntPtr previousTarget = SDL.GetRenderTarget(window.Renderer);
+
+            if (target != IntPtr.Zero)
+                SDL.SetRenderTarget(window.Renderer, target);
+
+            if (colors.Left.A > 0)
+            {
+                SDL.SetRenderDrawColor(window.Renderer, colors.Left.R, colors.Left.G, colors.Left.B, colors.Left.A);
+                SDL.RenderFillRect(window.Renderer, new SDL.FRect
+                {
+                    X = controlRect.X,
+                    Y = controlRect.Y,
+                    W = borderThickness.Left,
+                    H = controlRect.H
+                });
+            }
+
+            if (colors.Top.A > 0)
+            {
+                SDL.SetRenderDrawColor(window.Renderer, colors.Top.R, colors.Top.G, colors.Top.B, colors.Top.A);
+                SDL.RenderFillRect(window.Renderer, new SDL.FRect
+                {
+                    X = controlRect.X,
+                    Y = controlRect.Y,
+                    W = controlRect.W,
+                    H = borderThickness.Top
+                });
+            }
+
+            if (colors.Right.A > 0)
+            {
+                SDL.SetRenderDrawColor(window.Renderer, colors.Right.R, colors.Right.G, colors.Right.B, colors.Right.A);
+                SDL.RenderFillRect(window.Renderer, new SDL.FRect
+                {
+                    X = controlRect.X + controlRect.W - borderThickness.Right,
+                    Y = controlRect.Y,
+                    W = borderThickness.Right,
+                    H = controlRect.H
+                });
+            }
+
+            if (colors.Bottom.A > 0)
+            {
+                SDL.SetRenderDrawColor(window.Renderer, colors.Bottom.R, colors.Bottom.G, colors.Bottom.B, colors.Bottom.A);
+                SDL.RenderFillRect(window.Renderer, new SDL.FRect
+                {
+                    X = controlRect.X,
+                    Y = controlRect.Y + controlRect.H - borderThickness.Bottom,
+                    W = controlRect.W,
+                    H = borderThickness.Bottom
+                });
+            }
+
+            if (target != IntPtr.Zero)
+                SDL.SetRenderTarget(window.Renderer, previousTarget);
+        }
 
         #endregion
 
@@ -328,6 +386,17 @@ namespace PhotonUI
             SDL.FRect drawSurface = control.DrawRect;
 
             DrawRectangle(control.Window!, drawSurface, adjusted, control.Window?.BackTexture ?? default);
+        }
+
+        public static void DrawControlBorder<T>(T control) where T : Control, IBorderProperties, IControlProperties
+        {
+            EnsureRootWindow(control);
+
+            BorderColors adjusted = control.BorderColors.WithOpacity(control.Opacity);
+
+            SDL.FRect drawSurface = control.DrawRect;
+
+            DrawBorder(control.Window!, drawSurface, control.BorderThickness, adjusted, control.Window!.BackTexture);
         }
 
         #endregion


### PR DESCRIPTION
## Description
Adds a `Border` decorator control to the Photon UI framework. This control can wrap any child control and provides configurable border thickness and colors per side. Supporting models (`BorderColors`, `BorderProperties`, `IBorderProperties`) were introduced, and rendering has been extended to draw borders with automatic measure, arrange, and render integration.

## Related Issue
- Resolves #37

## Motivation and Context
This change allows developers to visually emphasize or separate UI elements without modifying the underlying controls, improving the styling and decoration capabilities of the framework.

## How Has This Been Tested?
- Verified compilation was successful

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.