### PR TITLE
Adding UserControl Base Composite

### DIFF
--- a/PhotonUI/Controls/Composites/UserControl.cs
+++ b/PhotonUI/Controls/Composites/UserControl.cs
@@ -1,0 +1,8 @@
+﻿using PhotonUI.Interfaces.Services;
+
+namespace PhotonUI.Controls.Composites
+{
+    public abstract class UserControl(IServiceProvider serviceProvider, IBindingService bindingService)
+        : Presenter(serviceProvider, bindingService)
+    { }
+}


### PR DESCRIPTION
## Description

Introduces an abstract `UserControl` class that inherits from `Presenter` and can host child controls. This class provides a foundation for building reusable composite controls in PhotonUI, supporting data binding via `IBindingService` and integrating into the existing layout, measure, and arrange lifecycle. It enables developers to create self-contained UI components without modifying the core framework.

## Related Issue

- Resolves #41

## Motivation and Context

Creating reusable, self-contained composite controls is a common need in UI frameworks. By providing a `UserControl` base, developers can focus on custom behavior and child composition without re-implementing presenter logic, binding, or layout management. This improves maintainability, consistency, and code reuse across the PhotonUI ecosystem.

## How Has This Been Tested?

* Verified compilation was successful

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Asset change (adds or updates icons, templates, or other assets)
* [ ] Documentation change (adds or updates documentation)
* [ ] Plugin change (adds or updates a plugin)

## Checklist:

* [x] I have read the **CONTRIBUTING** document.
* [x] My change requires a change to the core logic.
  * [x] I have linked the project issue above.
* [ ] My change requires a change to the assets.
  * [ ] I have linked the asset issue above.
* [ ] My change requires a change to the documentation.
  * [ ] I have linked the documentation issue above.
* [ ] My change requires a change to a plugin.
  * [ ] I have linked the plugin issue above.