### PR TITLE
Adding UserWindow Composite Control

### DIFF
--- a/PhotonUI/Controls/Composites/UserWindow.cs
+++ b/PhotonUI/Controls/Composites/UserWindow.cs
@@ -1,0 +1,8 @@
+﻿using PhotonUI.Interfaces.Services;
+
+namespace PhotonUI.Controls.Composites
+{
+    public partial class UserWindow(IServiceProvider serviceProvider, IBindingService bindingService)
+        : Window(serviceProvider, bindingService)
+    { }
+}


### PR DESCRIPTION
## Description
Introduces a `UserWindow` composite control that derives from the existing `Window` class. This allows UI developers to create custom windows while keeping the core `Window` logic untouched, enabling safe extension and specialized behavior within the PhotonUI framework.

## Related Issue
- Resolves #45

## Motivation and Context
This change is required so that UI developers can instantiate and extend windows without modifying the core `Window` class. It provides a clear semantic entry point for user-defined window behaviors, improving framework extensibility and maintainability.

## How Has This Been Tested?
- Verified compilation was successful

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.