### PR TITLE
Adding ClickSurface control

### DIFF
--- a/PhotonUI/Controls/Interaction/ClickSurface.cs
+++ b/PhotonUI/Controls/Interaction/ClickSurface.cs
@@ -1,0 +1,192 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Controls.Decorators;
+using PhotonUI.Events;
+using PhotonUI.Events.Platform;
+using PhotonUI.Extensions;
+using PhotonUI.Interfaces;
+using PhotonUI.Interfaces.Services;
+using PhotonUI.Models;
+using PhotonUI.Models.Properties;
+using SDL3;
+using System.Windows.Input;
+
+namespace PhotonUI.Controls.Interaction
+{
+    public partial class ClickSurface(IServiceProvider serviceProvider, IBindingService bindingService)
+        : Border(serviceProvider, bindingService), IBorderProperties, IHoverProperties, IPressedProperties
+    {
+        protected bool IsHovering = false;
+        protected bool IsPressed = false;
+
+        [ObservableProperty] private BorderColors borderColors = BorderProperties.Default.BorderColors;
+        [ObservableProperty] private Thickness borderThickness = BorderProperties.Default.BorderThickness;
+
+        [ObservableProperty] private SDL.Color hoverBackgroundColor = HoverProperties.Default.HoverBackgroundColor;
+        [ObservableProperty] private BorderColors hoverBorderColors = HoverProperties.Default.HoverBorderColors;
+        [ObservableProperty] private Thickness hoverBorderThickness = HoverProperties.Default.HoverBorderThickness;
+        [ObservableProperty] private SDL.Color hoverTextColor = HoverProperties.Default.HoverTextColor;
+        [ObservableProperty] private float hoverOpacity = HoverProperties.Default.HoverOpacity;
+        [ObservableProperty] private float hoverScale = HoverProperties.Default.HoverScale;
+
+        [ObservableProperty] private SDL.Color pressedBackgroundColor = PressedProperties.Default.PressedBackgroundColor;
+        [ObservableProperty] private BorderColors pressedBorderColors = PressedProperties.Default.PressedBorderColors;
+        [ObservableProperty] private Thickness pressedBorderThickness = PressedProperties.Default.PressedBorderThickness;
+        [ObservableProperty] private SDL.Color pressedTextColor = PressedProperties.Default.PressedTextColor;
+        [ObservableProperty] private float pressedOpacity = PressedProperties.Default.PressedOpacity;
+        [ObservableProperty] private float pressedScale = PressedProperties.Default.PressedScale;
+
+        public Action<MouseClickEventArgs>? OnClickAction { get; set; }
+
+        public ICommand? OnClick { get; set; }
+
+        #region ClickSurface: Framework
+
+        public override void ApplyStyles(params IStyleProperties[] properties)
+        {
+            this.ValidateStyles(properties);
+
+            base.ApplyStyles(properties);
+
+            foreach (IStyleProperties prop in properties)
+            {
+                switch (prop)
+                {
+                    case IBorderProperties props:
+                        this.ApplyProperties(props);
+                        break;
+
+                    case IHoverProperties props:
+                        this.ApplyProperties(props);
+                        break;
+
+                    case IPressedProperties props:
+                        this.ApplyProperties(props);
+                        break;
+                }
+            }
+        }
+
+        public override void FrameworkRender(Window window, SDL.Rect? clipRect = null)
+        {
+            if (this.IsVisible)
+            {
+                Photon.GetControlClipRect(this.DrawRect, this.ClipToBounds, clipRect, out SDL.Rect? effectiveClipRect);
+
+                if (effectiveClipRect.HasValue)
+                {
+                    Photon.ApplyControlClipRect(window, effectiveClipRect);
+
+                    Photon.DrawControlBackground(this, this.GetControlPropertiesState());
+                    Photon.DrawControlBorder(this, this.GetBorderPropertiesState(), this.GetControlPropertiesState());
+
+                    SDL.Rect modifiedClipRect = effectiveClipRect.Value.Deflate(this.BorderThickness);
+
+                    this.Child?.OnRender(window, modifiedClipRect);
+
+                    Photon.ApplyControlClipRect(window, clipRect);
+                }
+            }
+        }
+        #endregion
+
+        #region ClickSurface: Hooks
+
+        public override void OnEvent(Window window, FrameworkEventArgs e)
+        {
+            if (e.Handled || e.Preview) return;
+
+            base.OnEvent(window, e);
+
+            switch (e)
+            {
+                case MouseEnterEventArgs:
+                    this.IsHovering = true;
+                    this.RequestRender();
+                    e.Handled = true;
+                    break;
+
+                case MouseExitEventArgs:
+                    this.IsHovering = false;
+                    this.RequestRender();
+                    e.Handled = true;
+                    break;
+            }
+
+            if (e is not MouseClickEventArgs mouseClick) return;
+
+            switch (mouseClick.NativeEvent.Type)
+            {
+                case (uint)SDL.EventType.MouseButtonDown:
+                    if (mouseClick.Clicked == this || this.IsDescendant(mouseClick.Clicked))
+                    {
+                        this.IsPressed = true;
+                        this.RequestRender();
+                        window.CaptureMouse(this);
+                        e.Handled = true;
+                    }
+                    break;
+
+                case (uint)SDL.EventType.MouseButtonUp:
+                    if (mouseClick.Clicked == this || this.IsDescendant(mouseClick.Clicked))
+                    {
+                        if (this.IsHovering && this.IsPressed)
+                        {
+                            this.OnClick?.Execute(mouseClick);
+                            this.OnClickAction?.Invoke(mouseClick);
+                        }
+
+                        this.IsPressed = false;
+                        this.RequestRender();
+                        window.ReleaseMouse();
+                        e.Handled = true;
+                    }
+                    break;
+            }
+        }
+
+        #endregion
+
+        #region ClickSurface: Helpers
+
+        protected virtual ControlProperties GetControlPropertiesState()
+        {
+            ControlProperties props = this.FromControl<ControlProperties>();
+
+            if (this.IsPressed)
+            {
+                return props with { BackgroundColor = this.PressedBackgroundColor };
+            }
+            else if (this.IsHovering)
+            {
+                return props with { BackgroundColor = this.HoverBackgroundColor };
+            }
+
+            return props;
+        }
+        protected virtual BorderProperties GetBorderPropertiesState()
+        {
+            BorderProperties props = this.FromControl<BorderProperties>();
+
+            if (this.IsPressed)
+            {
+                return props with
+                {
+                    BorderColors = this.PressedBorderColors,
+                    BorderThickness = this.PressedBorderThickness
+                };
+            }
+            else if (this.IsHovering)
+            {
+                return props with
+                {
+                    BorderColors = this.HoverBorderColors,
+                    BorderThickness = this.HoverBorderThickness
+                };
+            }
+
+            return props;
+        }
+
+        #endregion
+    }
+}

--- a/PhotonUI/Models/Properties/HoverProperties.cs
+++ b/PhotonUI/Models/Properties/HoverProperties.cs
@@ -1,0 +1,33 @@
+﻿using PhotonUI.Interfaces;
+using SDL3;
+
+namespace PhotonUI.Models.Properties
+{
+    public interface IHoverProperties : IStyleProperties
+    {
+        SDL.Color HoverBackgroundColor { get; }
+        BorderColors HoverBorderColors { get; }
+        Thickness HoverBorderThickness { get; }
+        SDL.Color HoverTextColor { get; }
+        float HoverOpacity { get; }
+        float HoverScale { get; }
+    }
+
+    public readonly record struct HoverProperties(
+        SDL.Color HoverBackgroundColor,
+        BorderColors HoverBorderColors,
+        Thickness HoverBorderThickness,
+        SDL.Color HoverTextColor,
+        float HoverOpacity,
+        float HoverScale) : IHoverProperties
+    {
+        public static HoverProperties Default => new(
+            new SDL.Color { R = 240, G = 240, B = 240, A = 255 },
+            new BorderColors(new SDL.Color { R = 200, G = 200, B = 200, A = 255 }),
+            new Thickness(1),
+            new SDL.Color { R = 0, G = 0, B = 0, A = 255 },
+            1.0f,
+            1.0f
+        );
+    }
+}

--- a/PhotonUI/Models/Properties/PressedProperties .cs
+++ b/PhotonUI/Models/Properties/PressedProperties .cs
@@ -1,0 +1,32 @@
+﻿using PhotonUI.Interfaces;
+using SDL3;
+
+namespace PhotonUI.Models.Properties
+{
+    public interface IPressedProperties : IStyleProperties
+    {
+        SDL.Color PressedBackgroundColor { get; }
+        BorderColors PressedBorderColors { get; }
+        Thickness PressedBorderThickness { get; }
+        SDL.Color PressedTextColor { get; }
+        float PressedOpacity { get; }
+        float PressedScale { get; }
+    }
+
+    public readonly record struct PressedProperties(
+        SDL.Color PressedBackgroundColor,
+        BorderColors PressedBorderColors,
+        Thickness PressedBorderThickness,
+        SDL.Color PressedTextColor,
+        float PressedOpacity,
+        float PressedScale) : IPressedProperties
+    {
+        public static PressedProperties Default => new(
+            new SDL.Color { R = 220, G = 220, B = 220, A = 255 },
+            new BorderColors(new SDL.Color { R = 160, G = 160, B = 160, A = 255 }),
+            new Thickness(1),
+            new SDL.Color { R = 0, G = 0, B = 0, A = 255 },
+            0.95f,
+            0.98f);
+    }
+}

--- a/PhotonUI/Photon.cs
+++ b/PhotonUI/Photon.cs
@@ -3,6 +3,10 @@ using PhotonUI.Extensions;
 using PhotonUI.Models;
 using PhotonUI.Models.Properties;
 using SDL3;
+using System.Diagnostics;
+using System.Numerics;
+using System.Reflection;
+using System.Text;
 
 namespace PhotonUI
 {
@@ -387,6 +391,22 @@ namespace PhotonUI
 
             DrawRectangle(control.Window!, drawSurface, adjusted, control.Window?.BackTexture ?? default);
         }
+        public static void DrawControlBackground<T>(T control, ControlProperties props) where T : Control, IControlProperties
+        {
+            EnsureRootWindow(control);
+
+            SDL.Color adjusted = new()
+            {
+                R = props.BackgroundColor.R,
+                G = props.BackgroundColor.G,
+                B = props.BackgroundColor.B,
+                A = (byte)(props.BackgroundColor.A * props.Opacity)
+            };
+
+            SDL.FRect drawSurface = control.DrawRect;
+
+            DrawRectangle(control.Window!, drawSurface, adjusted, control.Window?.BackTexture ?? default);
+        }
 
         public static void DrawControlBorder<T>(T control) where T : Control, IBorderProperties, IControlProperties
         {
@@ -397,6 +417,17 @@ namespace PhotonUI
             SDL.FRect drawSurface = control.DrawRect;
 
             DrawBorder(control.Window!, drawSurface, control.BorderThickness, adjusted, control.Window!.BackTexture);
+        }
+        public static void DrawControlBorder<T>(T control, BorderProperties props, ControlProperties controlProps)
+            where T : Control, IBorderProperties
+        {
+            EnsureRootWindow(control);
+
+            BorderColors adjusted = props.BorderColors.WithOpacity(controlProps.Opacity);
+
+            SDL.FRect drawSurface = control.DrawRect;
+
+            DrawBorder(control.Window!, drawSurface, props.BorderThickness, adjusted, control.Window!.BackTexture);
         }
 
         #endregion


### PR DESCRIPTION
## Description

This PR introduces a new `ClickSurface` control that extends `Border` and provides hover and pressed visual states for UI elements. It supports both direct action callbacks (`OnClickAction`) and `ICommand` binding (`OnClick`), and integrates with the PhotonUI rendering pipeline. Additional helper methods in `Photon.cs` for drawing and transforming controls are included to support these interactive surfaces.

## Related Issue

- Resolves #47

## Motivation and Context

UI developers need a reusable, interactive surface that can respond to hover and click events without manually managing rendering logic or state. This allows creation of custom buttons, clickable regions, and other interactive elements while keeping core controls untouched.

## How Has This Been Tested?

* Verified that the solution can compile

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Asset change (adds or updates icons, templates, or other assets)
* [ ] Documentation change (adds or updates documentation)
* [ ] Plugin change (adds or updates a plugin)

## Checklist:

* [x] I have read the **CONTRIBUTING** document.
* [x] My change requires a change to the core logic.
  * [x] I have linked the project issue above.
* [ ] My change requires a change to the assets.
  * [ ] I have linked the asset issue above.
* [ ] My change requires a change to the documentation.
  * [ ] I have linked the documentation issue above.
* [ ] My change requires a change to a plugin.
  * [ ] I have linked the plugin issue above.