### PR TITLE
Adding ImageBlock Control with Texture Service

### DIFF
--- a/PhotonUI/Controls/Content/ImageBlock.cs
+++ b/PhotonUI/Controls/Content/ImageBlock.cs
@@ -1,0 +1,224 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Interfaces;
+using PhotonUI.Interfaces.Services;
+using PhotonUI.Models;
+using PhotonUI.Models.Properties;
+using SDL3;
+using System.ComponentModel;
+
+namespace PhotonUI.Controls.Content
+{
+    public partial class ImageBlock(IServiceProvider serviceProvider, IBindingService bindingService, ITextureService textureService)
+        : Control(serviceProvider, bindingService), IImageProperties, IStretchProperties
+    {
+        protected readonly ITextureService TextureService = textureService;
+
+        protected bool IsImageDirty = true;
+
+        protected IntPtr? SourceTexture = null;
+        protected Size SourceTextureSize = Size.Empty;
+        protected Size SourceControlSize = Size.Empty;
+
+        [ObservableProperty] private string imageSourceName = ImageProperties.Default.ImageSourceName;
+        [ObservableProperty] private SDL.FRect? imageSourceRect = ImageProperties.Default.ImageSourceRect;
+        [ObservableProperty] private SDL.Color imageTintColor = ImageProperties.Default.ImageTintColor;
+        [ObservableProperty] private SDL.BlendMode imageBlendMode = ImageProperties.Default.ImageBlendMode;
+
+        [ObservableProperty] private StretchMode stretchMode = StretchProperties.Default.StretchMode;
+        [ObservableProperty] private StretchDirection stretchDirection = StretchProperties.Default.StretchDirection;
+
+        #region Image: Framework
+
+        public override void ApplyStyles(params IStyleProperties[] properties)
+        {
+            this.ValidateStyles(properties);
+
+            base.ApplyStyles(properties);
+
+            foreach (IStyleProperties prop in properties)
+            {
+                switch (prop)
+                {
+                    case IImageProperties props:
+                        this.ApplyProperties(props);
+                        break;
+                    case IStretchProperties props:
+                        this.ApplyProperties(props);
+                        break;
+                }
+            }
+        }
+
+        public override void RequestRender(bool invalidate = true)
+        {
+            this.IsImageDirty = true;
+
+            base.RequestRender(invalidate);
+        }
+        public virtual void RequestRenderWithFlags(bool imageDirty = false, bool invalidate = true)
+        {
+            if (imageDirty)
+                this.IsImageDirty = true;
+
+            base.RequestRender(invalidate);
+        }
+
+        public override void FrameworkInitialize(Window window)
+        {
+            base.FrameworkInitialize(window);
+
+            if (this.LoadSourceTexture(window))
+                this.RebuildTexture(window);
+        }
+        public override void FrameworkRender(Window window, SDL.Rect? clipRect)
+        {
+            if (this.IsVisible)
+            {
+                Photon.GetControlClipRect(this.DrawRect, this.ClipToBounds, clipRect, out SDL.Rect? effectiveClipRect);
+
+                if (effectiveClipRect.HasValue)
+                {
+                    Photon.ApplyControlClipRect(window, effectiveClipRect);
+
+                    Photon.DrawControlBackground(this);
+
+                    if (this.SourceTexture.HasValue && this.SourceTexture.Value != IntPtr.Zero)
+                    {
+                        if (this.IsImageDirty)
+                        {
+                            this.RebuildTexture(window);
+                            this.IsImageDirty = false;
+                        }
+
+                        SDL.FRect destination = new()
+                        {
+                            X = this.DrawRect.X,
+                            Y = this.DrawRect.Y,
+                            W = this.SourceControlSize.Width > 0f ? this.SourceControlSize.Width : this.SourceTextureSize.Width,
+                            H = this.SourceControlSize.Height > 0f ? this.SourceControlSize.Height : this.SourceTextureSize.Height
+                        };
+
+                        if (this.ImageSourceRect.HasValue)
+                            Photon.DrawControlTexture(this, this.SourceTexture.Value, destination, this.ImageSourceRect.Value, effectiveClipRect.Value);
+                        else
+                            Photon.DrawControlTexture(this, this.SourceTexture.Value, destination, effectiveClipRect.Value);
+                    }
+
+                    Photon.ApplyControlClipRect(window, clipRect);
+
+                    this.RenderedAction?.Invoke(this);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Image: Hooks
+
+        protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+        {
+            if (!this.IsInitialized)
+                return;
+
+            if (this.Window == null)
+                throw new InvalidOperationException("Image property change: RootWindow == null.");
+
+            base.OnPropertyChanged(e);
+
+            bool invalidateMeasure = false;
+            bool invalidateLayout = false;
+            bool invalidateRender = false;
+            bool invalidateImage = false;
+
+            switch (e.PropertyName)
+            {
+                case nameof(this.ImageSourceName):
+                case nameof(this.ImageSourceRect):
+                    invalidateMeasure = true;
+                    invalidateLayout = true;
+                    invalidateRender = true;
+                    invalidateImage = true;
+                    break;
+            }
+
+            if (invalidateMeasure)
+                this.Parent?.RequestMeasure();
+
+            if (invalidateLayout)
+                this.Parent?.RequestArrange();
+
+            if (invalidateRender)
+                this.RequestRenderWithFlags(imageDirty: invalidateImage);
+        }
+
+        public override void Dispose()
+        {
+            if (this.SourceTexture.HasValue && this.SourceTexture.Value != IntPtr.Zero)
+            {
+                SDL.DestroyTexture(this.SourceTexture.Value);
+
+                this.SourceTexture = null;
+            }
+
+            GC.SuppressFinalize(this);
+
+            base.Dispose();
+        }
+
+        #endregion
+
+        #region Image: Helpers
+
+        protected virtual void RebuildTexture(Window window)
+        {
+            if (!this.SourceTexture.HasValue || this.SourceTexture.Value == IntPtr.Zero)
+                return;
+
+            byte alpha = (byte)Math.Clamp((int)(this.Opacity * 255), 0, 255);
+
+            SDL.SetTextureColorMod(this.SourceTexture.Value, this.ImageTintColor.R, this.ImageTintColor.G, this.ImageTintColor.B);
+            SDL.SetTextureAlphaMod(this.SourceTexture.Value, alpha);
+            SDL.SetTextureBlendMode(this.SourceTexture.Value, this.ImageBlendMode);
+
+            this.SourceControlSize =
+                Photon.GetScaledSize(
+                    new Size(this.DrawRect.W, this.DrawRect.H),
+                    new Size(this.SourceTextureSize.Width, this.SourceTextureSize.Height),
+                    this.FromControl<StretchProperties>());
+        }
+
+        protected virtual bool LoadSourceTexture(Window window)
+        {
+            if (this.SourceTexture.HasValue && this.SourceTexture.Value != IntPtr.Zero)
+            {
+                SDL.DestroyTexture(this.SourceTexture.Value);
+
+                this.SourceTexture = null;
+            }
+
+            if (string.IsNullOrEmpty(this.ImageSourceName))
+            {
+                this.SourceControlSize = new Size(0);
+                this.SourceTextureSize = Size.Empty;
+
+                return false;
+            }
+
+            if (this.TextureService.CreateTexture(window.Renderer, this.ImageSourceName, out nint texture, out Size natural))
+            {
+                this.SourceTexture = texture;
+                this.SourceTextureSize = natural;
+
+                return true;
+            }
+
+            this.SourceTexture = IntPtr.Zero;
+            this.SourceTextureSize = Size.Empty;
+            this.SourceControlSize = new Size(0);
+
+            return false;
+        }
+
+        #endregion
+    }
+}

--- a/PhotonUI/Interfaces/Services/ITextureService.cs
+++ b/PhotonUI/Interfaces/Services/ITextureService.cs
@@ -1,0 +1,14 @@
+﻿using PhotonUI.Models;
+
+namespace PhotonUI.Interfaces.Services
+{
+    public interface ITextureService
+    {
+        void LoadSurface(string path, string name);
+        Size GetSurfaceSize(string name);
+        bool CreateTexture(IntPtr renderer, string name, out IntPtr texture, out Size size);
+        void UnloadSurface(string name);
+        void Dispose();
+        void LoadEmbeddedSurface(string resourceId, string name);
+    }
+}

--- a/PhotonUI/Models/Properties/ImageProperties.cs
+++ b/PhotonUI/Models/Properties/ImageProperties.cs
@@ -1,0 +1,27 @@
+﻿using PhotonUI.Interfaces;
+using SDL3;
+
+namespace PhotonUI.Models.Properties
+{
+    public interface IImageProperties : IStyleProperties
+    {
+        string ImageSourceName { get; }
+        SDL.FRect? ImageSourceRect { get; }
+        SDL.Color ImageTintColor { get; }
+        SDL.BlendMode ImageBlendMode { get; }
+    }
+
+    public readonly record struct ImageProperties(
+        string ImageSourceName,
+        SDL.FRect? ImageSourceRect,
+        SDL.Color ImageTintColor,
+        SDL.BlendMode ImageBlendMode) : IImageProperties
+    {
+        public static ImageProperties Default => new(
+            string.Empty,
+            null,
+            new SDL.Color { R = 255, G = 255, B = 255, A = 255 },
+            SDL.BlendMode.Blend
+        );
+    }
+}

--- a/PhotonUI/Services/TextureService.cs
+++ b/PhotonUI/Services/TextureService.cs
@@ -1,0 +1,140 @@
+﻿using PhotonUI.Interfaces.Services;
+using PhotonUI.Models;
+using SDL3;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace PhotonUI.Services
+{
+    public class TextureService : IDisposable, ITextureService
+    {
+        protected record SurfaceEntry(IntPtr Handle, int Width, int Height, string Path);
+
+        protected readonly Dictionary<string, Stack<SurfaceEntry>> Cache = [];
+
+        public void LoadSurface(string path, string name)
+        {
+            IntPtr surfacePtr = Image.Load(path);
+
+            if (surfacePtr == IntPtr.Zero)
+                throw new Exception($"Failed to load image: {path}");
+
+            SDL.Surface surface = Marshal.PtrToStructure<SDL.Surface>(surfacePtr);
+            SurfaceEntry entry = new(surfacePtr, surface.Width, surface.Height, path);
+
+            if (!this.Cache.TryGetValue(name, out Stack<SurfaceEntry>? stack))
+            {
+                stack = new Stack<SurfaceEntry>();
+                this.Cache[name] = stack;
+            }
+
+            stack.Push(entry);
+        }
+        public void LoadEmbeddedSurface(string resourceId, string name)
+        {
+            Assembly appAssembly = Assembly.GetEntryAssembly()
+                ?? throw new InvalidOperationException("No entry assembly found");
+
+            using Stream? stream = appAssembly.GetManifestResourceStream(resourceId)
+                ?? throw new Exception($"Embedded resource not found: {resourceId}");
+
+            using MemoryStream ms = new();
+            stream.CopyTo(ms);
+            byte[] data = ms.ToArray();
+
+            GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+
+            try
+            {
+                IntPtr ptr = handle.AddrOfPinnedObject();
+                nuint size = (nuint)data.Length;
+
+                IntPtr io = SDL.IOFromConstMem(ptr, size);
+                IntPtr surfacePtr = Image.LoadIO(io, false);
+
+                SDL.CloseIO(io);
+
+                if (surfacePtr == IntPtr.Zero)
+                    throw new Exception($"SDL image load failed: {SDL.GetError()}");
+
+                SDL.Surface surface = Marshal.PtrToStructure<SDL.Surface>(surfacePtr);
+                SurfaceEntry entry = new(surfacePtr, surface.Width, surface.Height, $"embedded:{resourceId}");
+
+                if (!this.Cache.TryGetValue(name, out Stack<SurfaceEntry>? stack))
+                {
+                    stack = new Stack<SurfaceEntry>();
+
+                    this.Cache[name] = stack;
+                }
+
+                stack.Push(entry);
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+        public IntPtr GetSurface(string name)
+        {
+            if (!this.Cache.TryGetValue(name, out Stack<SurfaceEntry>? stack) || stack.Count == 0)
+                throw new InvalidOperationException($"Surface not loaded: {name}");
+
+            return stack.Peek().Handle;
+        }
+        public IEnumerable<(string Path, int Width, int Height)> GetAllSurfaces(string name)
+        {
+            if (!this.Cache.TryGetValue(name, out Stack<SurfaceEntry>? stack)) return [];
+
+            return stack.Select(e => (e.Path, e.Width, e.Height));
+        }
+        public void UnloadSurface(string name)
+        {
+            if (this.Cache.TryGetValue(name, out Stack<SurfaceEntry>? stack) && stack.Count > 0)
+            {
+                SurfaceEntry entry = stack.Pop();
+                SDL.DestroySurface(entry.Handle);
+
+                if (stack.Count == 0)
+                    this.Cache.Remove(name);
+            }
+        }
+
+        public Size GetSurfaceSize(string name)
+        {
+            if (!this.Cache.TryGetValue(name, out Stack<SurfaceEntry>? stack) || stack.Count == 0)
+                throw new InvalidOperationException($"Surface not loaded: {name}");
+
+            SurfaceEntry entry = stack.Peek();
+
+            return new Size(entry.Width, entry.Height);
+        }
+        public bool CreateTexture(IntPtr renderer, string name, out IntPtr texture, out Size size)
+        {
+            texture = IntPtr.Zero;
+            size = Size.Empty;
+
+            if (!this.Cache.TryGetValue(name, out Stack<SurfaceEntry>? stack) || stack.Count == 0)
+                return false;
+
+            SurfaceEntry entry = stack.Peek();
+            SDL.Surface surface = Marshal.PtrToStructure<SDL.Surface>(entry.Handle);
+
+            size = new Size(surface.Width, surface.Height);
+            texture = SDL.CreateTextureFromSurface(renderer, entry.Handle);
+
+            return texture != IntPtr.Zero;
+        }
+
+        public void Dispose()
+        {
+            foreach (Stack<SurfaceEntry> stack in this.Cache.Values)
+                foreach (SurfaceEntry entry in stack)
+                    SDL.DestroySurface(entry.Handle);
+
+            this.Cache.Clear();
+
+            GC.SuppressFinalize(this);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR introduces a new `ImageBlock` control and a supporting `TextureService`. `ImageBlock` provides:

- Loading images from file or embedded resources
- Tinting, blending, and opacity control
- Stretch modes (Fill, Uniform, UniformToFill, None)
- Stretch directions (UpOnly, DownOnly)
- Automatic resizing and scaling based on control size
- Integration with existing rendering and layout pipelines

`TextureService` manages image surfaces and textures, providing caching, loading, and conversion to textures for use by controls like `ImageBlock`.

## Related Issue
- Resolves #51

## Motivation and Context
A standardized image display control and texture management system are required to:

- Display images reliably within UI layouts
- Eliminate the need for custom image handling in individual controls
- Provide reusable texture management for both file-based and embedded images

## How Has This Been Tested?
- Verified that the code compiles successfully.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.