### PR TITLE
Adding SpriteBlock Control with Clip Playback Support

### DIFF
--- a/PhotonUI/Components/ClipPlayer.cs
+++ b/PhotonUI/Components/ClipPlayer.cs
@@ -1,0 +1,142 @@
+﻿using PhotonUI.Interfaces.Clips;
+using PhotonUI.Models.Clips;
+using PhotonUI.Services;
+using SDL3;
+
+namespace PhotonUI.Components
+{
+    public class ClipPlayer(ClipSequence clip)
+    {
+        protected readonly ClipSequence Clip = clip
+            ?? throw new ArgumentNullException(nameof(clip));
+
+        protected long StartTicks = -1;
+        protected int FrameIndex = 0;
+
+        public virtual float PlaybackSpeed { get; set; } = 1.0f;
+        public virtual bool Looping { get; set; } = true;
+        public virtual PlaybackDirection Direction { get; set; } = PlaybackDirection.Forward;
+        public virtual bool IsPlaying { get; protected set; } = false;
+        public virtual int CurrentFrameIndex => this.FrameIndex;
+
+        public virtual int TotalDuration
+        {
+            get
+            {
+                int total = 0;
+
+                for (int i = 0; i < this.Clip.FrameCount; i++)
+                    total += this.Clip.GetFrame(i).IntervalMs;
+
+                return total;
+            }
+        }
+        public virtual ulong ElapsedTime
+        {
+            get
+            {
+                if (this.StartTicks == -1) return 0;
+
+                return (ulong)((SDL.GetTicks() - (ulong)this.StartTicks) * this.PlaybackSpeed);
+            }
+        }
+
+        public virtual void Play()
+        {
+            this.IsPlaying = true;
+            if (this.StartTicks == -1)
+                this.StartTicks = (long)SDL.GetTicks();
+        }
+        public virtual void Seek(int frameIndex)
+        {
+            if (frameIndex < 0 || frameIndex >= this.Clip.FrameCount)
+                throw new ArgumentOutOfRangeException(nameof(frameIndex));
+
+            this.FrameIndex = frameIndex;
+            this.StartTicks = (long)SDL.GetTicks();
+        }
+        public virtual void SeekToTime(TimeSpan time)
+        {
+            ulong targetMs = (ulong)(time.TotalMilliseconds * this.PlaybackSpeed);
+
+            int accumulated = 0;
+            for (int i = 0; i < this.Clip.FrameCount; i++)
+            {
+                accumulated += this.Clip.GetFrame(i).IntervalMs;
+                if (targetMs < (ulong)accumulated)
+                {
+                    this.FrameIndex = i;
+                    break;
+                }
+            }
+
+            this.StartTicks = (long)SDL.GetTicks() - (long)targetMs;
+        }
+        public virtual void Stop() => this.IsPlaying = false;
+        public virtual void Reset()
+        {
+            this.StartTicks = -1;
+        }
+
+        public virtual ClipFrame CurrentFrame
+        {
+            get
+            {
+                if (this.Clip.FrameCount == 0)
+                    throw new InvalidOperationException("No frames in clip.");
+
+                if (!this.IsPlaying)
+                {
+                    this.FrameIndex = 0;
+                    return this.Clip.GetFrame(0);
+                }
+
+                if (this.StartTicks == -1)
+                    this.StartTicks = (long)SDL.GetTicks();
+
+                ulong elapsed = this.ElapsedTime;
+
+                int frameIndex = 0;
+                int accumulated = 0;
+
+                for (int i = 0; i < this.Clip.FrameCount; i++)
+                {
+                    accumulated += this.Clip.GetFrame(i).IntervalMs;
+                    if (elapsed < (ulong)accumulated)
+                    {
+                        frameIndex = i;
+                        break;
+                    }
+                }
+
+                if (elapsed >= (ulong)this.TotalDuration)
+                {
+                    if (this.Looping)
+                    {
+                        ulong wrapped = elapsed % (ulong)this.TotalDuration;
+                        accumulated = 0;
+                        for (int i = 0; i < this.Clip.FrameCount; i++)
+                        {
+                            accumulated += this.Clip.GetFrame(i).IntervalMs;
+                            if (wrapped < (ulong)accumulated)
+                            {
+                                frameIndex = i;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        frameIndex = this.Clip.FrameCount - 1;
+                    }
+                }
+
+                if (this.Direction == PlaybackDirection.Reverse)
+                    frameIndex = this.Clip.FrameCount - 1 - frameIndex;
+
+                this.FrameIndex = frameIndex;
+                return this.Clip.GetFrame(frameIndex);
+            }
+        }
+    }
+}

--- a/PhotonUI/Controls/Content/SpriteBlock.cs
+++ b/PhotonUI/Controls/Content/SpriteBlock.cs
@@ -1,0 +1,402 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Components;
+using PhotonUI.Interfaces;
+using PhotonUI.Interfaces.Services;
+using PhotonUI.Models;
+using PhotonUI.Models.Clips;
+using PhotonUI.Models.Properties;
+using PhotonUI.Services;
+using SDL3;
+using System.ComponentModel;
+using System.Numerics;
+
+namespace PhotonUI.Controls.Content
+{
+    public partial class SpriteBlock(IServiceProvider serviceProvider, IBindingService bindingService, ITextureService textureService, IClipService clipService)
+        : ImageBlock(serviceProvider, bindingService, textureService), ISpriteProperties, IClipProperties
+    {
+        protected readonly IClipService ClipService = clipService;
+
+        protected bool IsPlayerDirty = true;
+        protected ClipPlayer? Player;
+        protected readonly Dictionary<int, IntPtr> FrameCache = [];
+        protected IntPtr CachedTexture = IntPtr.Zero;
+        protected SDL.FRect CachedDestination;
+        protected SDL.FRect CachedSourceRect;
+
+        [ObservableProperty] private bool flipX = SpriteProperties.Default.FlipX;
+        [ObservableProperty] private bool flipY = SpriteProperties.Default.FlipY;
+        [ObservableProperty] private float rotation = SpriteProperties.Default.Rotation;
+        [ObservableProperty] private Vector2 scale = SpriteProperties.Default.Scale;
+        [ObservableProperty] private SDL.FPoint anchorPoint = SpriteProperties.Default.AnchorPoint;
+        [ObservableProperty] private float playbackSpeed = SpriteProperties.Default.PlaybackSpeed;
+        [ObservableProperty] private bool looping = SpriteProperties.Default.Looping;
+        [ObservableProperty] private PlaybackDirection direction = SpriteProperties.Default.Direction;
+        [ObservableProperty] private bool bakePlayback = SpriteProperties.Default.BakePlayback;
+
+        [ObservableProperty] private int framesWide = ClipProperties.Default.FramesWide;
+        [ObservableProperty] private int framesTall = ClipProperties.Default.FramesTall;
+        [ObservableProperty] private int offsetX = ClipProperties.Default.OffsetX;
+        [ObservableProperty] private int offsetY = ClipProperties.Default.OffsetY;
+        [ObservableProperty] private IReadOnlyDictionary<int, ulong> frameDurations = ClipProperties.Default.FrameDurations;
+
+        public void Play()
+            => this.Player?.Play();
+        public void Seek(int frameIndex)
+            => this.Player?.Seek(frameIndex);
+        public void SeekToTime(TimeSpan time)
+            => this.Player?.SeekToTime(time);
+        public void Stop()
+            => this.Player?.Stop();
+        public void Reset()
+            => this.Player?.Reset();
+
+        #region SpriteBlock: Framework
+
+        public override void ApplyStyles(params IStyleProperties[] properties)
+        {
+            this.ValidateStyles(properties);
+
+            base.ApplyStyles(properties);
+
+            foreach (IStyleProperties prop in properties)
+            {
+                switch (prop)
+                {
+                    case ISpriteProperties props:
+                        this.ApplyProperties(props);
+                        break;
+                    case IClipProperties props:
+                        this.ApplyProperties(props);
+                        break;
+                }
+            }
+        }
+
+        public override void RequestRender(bool invalidate = true)
+        {
+            this.IsImageDirty = true;
+            this.IsPlayerDirty = true;
+
+            base.RequestRender(invalidate);
+        }
+        public virtual void RequestRenderWithFlags(bool imageDirty = false, bool playerDirty = false, bool invalidate = true)
+        {
+            if (imageDirty)
+                this.IsImageDirty = true;
+
+            if (playerDirty)
+                this.IsPlayerDirty = true;
+
+            base.RequestRender(invalidate);
+        }
+
+        public override void FrameworkMeasure(Window window)
+        {
+            Size frameSize = Size.Empty;
+
+            if (this.Player != null && this.Player.CurrentFrame != null)
+                frameSize = new Size()
+                {
+                    Width = this.Player.CurrentFrame.SourceRect.W,
+                    Height = this.Player.CurrentFrame.SourceRect.H
+                };
+
+            this.IntrinsicSize = Photon.GetMinimumSize(this, frameSize);
+        }
+
+        #endregion
+
+        #region SpriteBlock: Hooks
+
+        protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+        {
+            if (!this.IsInitialized)
+                return;
+
+            if (this.Window == null)
+                throw new InvalidOperationException("Sprite property change: RootWindow == null.");
+
+            base.OnPropertyChanged(e);
+
+            bool invalidateMeasure = false;
+            bool invalidateLayout = false;
+            bool invalidateRender = false;
+
+            switch (e.PropertyName)
+            {
+                case nameof(this.PlaybackSpeed):
+                    if (this.Player != null)
+                        this.Player.PlaybackSpeed = this.PlaybackSpeed;
+                    break;
+
+                case nameof(this.Looping):
+                    if (this.Player != null)
+                        this.Player.Looping = this.Looping;
+                    break;
+
+                case nameof(this.Direction):
+                    if (this.Player != null)
+                        this.Player.Direction = this.Direction;
+                    break;
+
+                case nameof(this.FramesWide):
+                case nameof(this.FramesTall):
+                case nameof(this.OffsetX):
+                case nameof(this.OffsetY):
+                case nameof(this.FrameDurations):
+                    invalidateMeasure = true;
+                    invalidateLayout = true;
+                    invalidateRender = true;
+                    if (this.TryLoadPlayer(this.Window)) this.Player?.Play();
+                    break;
+
+                case nameof(this.FlipX):
+                case nameof(this.FlipY):
+                case nameof(this.Rotation):
+                case nameof(this.Scale):
+                case nameof(this.AnchorPoint):
+                case nameof(this.ImageTintColor):
+                case nameof(this.Opacity):
+                case nameof(this.ImageBlendMode):
+                    invalidateMeasure = true;
+                    invalidateLayout = true;
+                    invalidateRender = true;
+                    this.ClearFrameCache();
+                    this.RequestRenderWithFlags(playerDirty: true);
+                    break;
+            }
+
+            if (invalidateMeasure)
+                this.Parent?.RequestMeasure();
+
+            if (invalidateLayout)
+                this.Parent?.RequestArrange();
+
+            if (invalidateRender)
+                this.RequestRenderWithFlags();
+        }
+
+        public override void OnInitialize(Window window)
+        {
+            base.OnInitialize(window);
+
+            if (this.TryLoadPlayer(window))
+                if (this.Player != null)
+                    this.IsPlayerDirty = false;
+        }
+        public override void OnTick(Window window)
+        {
+            base.OnTick(window);
+
+            if (this.IsImageDirty)
+            {
+                this.ClearFrameCache();
+
+                if (this.TryLoadPlayer(window))
+                {
+                    this.Player?.Play();
+                    this.IsPlayerDirty = false;
+                }
+
+                this.IsImageDirty = false;
+            }
+
+            if (this.Player == null || !this.Player.IsPlaying) return;
+
+            ClipFrame frame = this.Player.CurrentFrame;
+
+            int currentIndex = this.Player.CurrentFrameIndex;
+
+            if (this.FrameCache.TryGetValue(currentIndex, out IntPtr cached))
+            {
+                this.CachedTexture = cached;
+                this.CachedSourceRect = frame.SourceRect;
+                this.RequestRender(invalidate: true);
+            }
+            else
+            {
+                this.RebuildTexture(window, frame, currentIndex);
+                this.RequestRender(invalidate: true);
+            }
+        }
+        public override void OnRender(Window window, SDL.Rect? clipRect = null)
+        {
+            if (this.IsRenderDirty)
+            {
+                if (this.IsVisible)
+                {
+                    Photon.GetControlClipRect(this.DrawRect, this.ClipToBounds, clipRect, out SDL.Rect? effectiveClipRect);
+
+                    if (effectiveClipRect.HasValue)
+                    {
+                        Photon.ApplyControlClipRect(window, effectiveClipRect);
+
+                        Photon.DrawControlBackground(this);
+
+                        if (this.BakePlayback)
+                        {
+                            Photon.DrawControlTexture(this, this.CachedTexture, this.CachedDestination, this.CachedSourceRect, effectiveClipRect);
+                        }
+                        else
+                        {
+                            SDL.FRect destintation = this.CachedDestination;
+
+                            if (this.Scale != Vector2.One)
+                                destintation = Photon.ScaleRect(destintation, this.Scale, this.AnchorPoint);
+
+                            Photon.DrawControlTextureRotated(this, this.CachedTexture, destintation, this.CachedSourceRect, this.Rotation, this.AnchorPoint, this.GetFlipMode(), effectiveClipRect);
+                        }
+
+                        Photon.ApplyControlClipRect(window, clipRect);
+                    }
+                }
+
+                this.IsRenderDirty = false;
+                this.RenderedAction?.Invoke(this);
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            foreach (nint tex in this.FrameCache.Values)
+                if (tex != IntPtr.Zero)
+                    SDL.DestroyTexture(tex);
+
+            this.FrameCache.Clear();
+
+            if (this.CachedTexture != IntPtr.Zero)
+            {
+                SDL.DestroyTexture(this.CachedTexture);
+
+                this.CachedTexture = IntPtr.Zero;
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+
+        #region SpriteBlock: Helpers
+
+        protected virtual SDL.FlipMode GetFlipMode()
+        {
+            SDL.FlipMode flipMode = SDL.FlipMode.None;
+            if (this.FlipX && this.FlipY) flipMode = SDL.FlipMode.HorizontalAndVertical;
+            else if (this.FlipX) flipMode = SDL.FlipMode.Horizontal;
+            else if (this.FlipY) flipMode = SDL.FlipMode.Vertical;
+            return flipMode;
+        }
+
+        protected virtual void ClearFrameCache()
+        {
+            foreach (IntPtr tex in this.FrameCache.Values)
+            {
+                if (tex != IntPtr.Zero)
+                    SDL.DestroyTexture(tex);
+            }
+            this.FrameCache.Clear();
+        }
+
+        protected virtual bool TryLoadPlayer(Window window)
+        {
+            this.Player = null;
+
+            if (string.IsNullOrEmpty(this.ImageSourceName) || this.SourceTexture == null || this.SourceTexture == IntPtr.Zero)
+                return false;
+
+            try
+            {
+                this.Player = this.ClipService.GetPlayer(this.SourceTexture.Value, this.FramesWide, this.FramesTall, this.OffsetX, this.OffsetY);
+
+                return this.Player != null;
+            }
+            catch
+            {
+                this.Player = null;
+
+                return false;
+            }
+        }
+
+        protected virtual void RebuildTexture(Window window, ClipFrame frame, int frameIndex)
+        {
+            //TODO: Commented Out
+            /*
+            if (this.FrameCache.TryGetValue(frameIndex, out IntPtr oldTex) && oldTex != IntPtr.Zero)
+            {
+                SDL.DestroyTexture(oldTex);
+
+                this.FrameCache.Remove(frameIndex);
+            }
+
+            IntPtr newTex = Photon.CreateTexture(
+                window.Renderer,
+                (int)frame.SourceRect.W,
+                (int)frame.SourceRect.H,
+                SDL.PixelFormat.ARGB8888,
+                SDL.TextureAccess.Target
+            );
+
+            if (newTex == IntPtr.Zero)
+                return;
+
+            byte alpha = (byte)Math.Clamp((int)(this.Opacity * 255), 0, 255);
+            SDL.SetTextureColorMod(newTex, this.ImageTintColor.R, this.ImageTintColor.G, this.ImageTintColor.B);
+            SDL.SetTextureAlphaMod(newTex, alpha);
+            SDL.SetTextureBlendMode(newTex, this.ImageBlendMode);
+
+            if (this.BakePlayback)
+            {
+                SDL.FRect dest = new() { X = 0, Y = 0, W = frame.SourceRect.W, H = frame.SourceRect.H };
+
+                Photon.DrawTextureRotated(
+                    window,
+                    frame.Texture,
+                    frame.SourceRect,
+                    dest,
+                    this.Rotation,
+                    this.AnchorPoint,
+                    this.GetFlipMode(),
+                    newTex);
+            }
+            else
+            {
+                SDL.FRect dest = new() { X = 0, Y = 0, W = frame.SourceRect.W, H = frame.SourceRect.H };
+
+                Photon.DrawTexture(window, frame.Texture, dest, newTex, frame.SourceRect);
+            }
+
+            this.FrameCache[frameIndex] = newTex;
+            this.CachedTexture = newTex;
+            this.CachedSourceRect = new SDL.FRect { X = 0, Y = 0, W = frame.SourceRect.W, H = frame.SourceRect.H };
+
+            float availableW = this.Width > 0 ? this.Width : this.Parent?.ContentRect.W ?? frame.SourceRect.W;
+            float availableH = this.Height > 0 ? this.Height : this.Parent?.ContentRect.H ?? frame.SourceRect.H;
+
+            this.SourceControlSize = Photon.GetScaledSize(
+                new Size(availableW, availableH),
+                new Size(this.ContentRect.W, this.ContentRect.H),
+                this.FromControl<StretchProperties>()
+            );
+
+            SDL.FRect destRect = new()
+            {
+                X = this.RenderRect.X,
+                Y = this.RenderRect.Y,
+                W = this.SourceControlSize.Width,
+                H = this.SourceControlSize.Height
+            };
+
+            if (this.BakePlayback && this.Scale != Vector2.One)
+                destRect = Photon.ScaleRect(destRect, this.Scale, this.AnchorPoint);
+
+            this.CachedDestination = destRect;
+            */
+        }
+
+        #endregion
+    }
+}

--- a/PhotonUI/Interfaces/Clips/ClipFrame.cs
+++ b/PhotonUI/Interfaces/Clips/ClipFrame.cs
@@ -1,0 +1,11 @@
+﻿using SDL3;
+
+namespace PhotonUI.Models.Clips
+{
+    public class ClipFrame(IntPtr texture, SDL.FRect sourceRect, int intervalMs = 100)
+    {
+        public IntPtr Texture { get; } = texture;
+        public SDL.FRect SourceRect { get; } = sourceRect;
+        public int IntervalMs { get; } = intervalMs;
+    }
+}

--- a/PhotonUI/Interfaces/Clips/ClipSequence.cs
+++ b/PhotonUI/Interfaces/Clips/ClipSequence.cs
@@ -1,0 +1,24 @@
+﻿using PhotonUI.Models.Clips;
+
+namespace PhotonUI.Interfaces.Clips
+{
+    public class ClipSequence
+    {
+        private readonly List<ClipFrame> frames = [];
+
+        public int FrameCount => this.frames.Count;
+
+        public void AddFrame(ClipFrame frame)
+            => this.frames.Add(frame);
+
+        public ClipFrame GetFrame(int frameIndex)
+        {
+            if (this.frames.Count == 0)
+                throw new InvalidOperationException("No frames in clip.");
+
+            int index = frameIndex % this.frames.Count;
+
+            return this.frames[index];
+        }
+    }
+}

--- a/PhotonUI/Interfaces/Services/IClipService.cs
+++ b/PhotonUI/Interfaces/Services/IClipService.cs
@@ -1,0 +1,11 @@
+﻿using PhotonUI.Components;
+using PhotonUI.Interfaces.Clips;
+
+namespace PhotonUI.Interfaces.Services
+{
+    public interface IClipService
+    {
+        ClipSequence BuildFromSpriteSheet(IntPtr texture, int framesWide, int framesTall, int offsetX = 0, int offsetY = 0);
+        ClipPlayer GetPlayer(nint texture, int framesWide, int framesTall, int offsetX = 0, int offsetY = 0);
+    }
+}

--- a/PhotonUI/Models/Properties/ClipProperties.cs
+++ b/PhotonUI/Models/Properties/ClipProperties.cs
@@ -1,0 +1,37 @@
+﻿using PhotonUI.Interfaces;
+using PhotonUI.Services;
+
+namespace PhotonUI.Models.Properties
+{
+    public interface IClipProperties : IStyleProperties
+    {
+        int FramesWide { get; }
+        int FramesTall { get; }
+        int OffsetX { get; }
+        int OffsetY { get; }
+        IReadOnlyDictionary<int, ulong> FrameDurations { get; }
+    }
+
+    public readonly record struct ClipProperties(
+        int FramesWide,
+        int FramesTall,
+        int OffsetX,
+        int OffsetY,
+        float PlaybackSpeed,
+        bool Looping,
+        PlaybackDirection Direction,
+        IReadOnlyDictionary<int, ulong> FrameDurations
+    ) : IClipProperties
+    {
+        public static ClipProperties Default => new(
+            1,
+            1,
+            0,
+            0,
+            1.0f,
+            true,
+            PlaybackDirection.Forward,
+            new Dictionary<int, ulong> { { 0, 1000 } }
+        );
+    }
+}

--- a/PhotonUI/Models/Properties/SpirteProperties.cs
+++ b/PhotonUI/Models/Properties/SpirteProperties.cs
@@ -1,0 +1,44 @@
+﻿using PhotonUI.Interfaces;
+using PhotonUI.Services;
+using SDL3;
+using System.Numerics;
+
+namespace PhotonUI.Models.Properties
+{
+    public interface ISpriteProperties : IStyleProperties
+    {
+        bool FlipX { get; }
+        bool FlipY { get; }
+        float Rotation { get; }
+        Vector2 Scale { get; }
+        SDL.FPoint AnchorPoint { get; }
+        float PlaybackSpeed { get; }
+        bool Looping { get; }
+        PlaybackDirection Direction { get; }
+        bool BakePlayback { get; }
+    }
+
+    public readonly record struct SpriteProperties(
+        bool FlipX,
+        bool FlipY,
+        float Rotation,
+        Vector2 Scale,
+        SDL.FPoint AnchorPoint,
+        float PlaybackSpeed,
+        bool Looping,
+        PlaybackDirection Direction,
+        bool BakePlayback) : ISpriteProperties
+    {
+        public static SpriteProperties Default => new(
+            false,
+            false,
+            0f,
+            new Vector2(1f, 1f),
+            new SDL.FPoint() { X = 0.5f, Y = 0.5f },
+            1.0f,
+            true,
+            PlaybackDirection.Forward,
+            true
+        );
+    }
+}

--- a/PhotonUI/Services/ClipService.cs
+++ b/PhotonUI/Services/ClipService.cs
@@ -1,0 +1,51 @@
+﻿using PhotonUI.Components;
+using PhotonUI.Interfaces.Clips;
+using PhotonUI.Interfaces.Services;
+using PhotonUI.Models.Clips;
+using SDL3;
+
+namespace PhotonUI.Services
+{
+    public enum PlaybackDirection
+    {
+        Forward,
+        Reverse
+    }
+
+    public class ClipService : IClipService
+    {
+        public ClipSequence BuildFromSpriteSheet(IntPtr texture, int framesWide, int framesTall, int offsetX = 0, int offsetY = 0)
+        {
+            SDL.GetTextureSize(texture, out float texWidth, out float texHeight);
+
+            int frameWidth = (int)(texWidth - offsetX) / framesWide;
+            int frameHeight = (int)(texHeight - offsetY) / framesTall;
+
+            ClipSequence clip = new();
+
+            for (int y = 0; y < framesTall; y++)
+            {
+                for (int x = 0; x < framesWide; x++)
+                {
+                    SDL.FRect rect = new()
+                    {
+                        X = offsetX + x * frameWidth,
+                        Y = offsetY + y * frameHeight,
+                        W = frameWidth,
+                        H = frameHeight
+                    };
+
+                    clip.AddFrame(new ClipFrame(texture, rect));
+                }
+            }
+
+            return clip;
+        }
+        public ClipPlayer GetPlayer(IntPtr texture, int framesWide, int framesTall, int offsetX = 0, int offsetY = 0)
+        {
+            ClipSequence sequence = this.BuildFromSpriteSheet(texture, framesWide, framesTall, offsetX, offsetY);
+
+            return new ClipPlayer(sequence);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Introduces a new `SpriteBlock` control that supports sprite sheet-based animations using `ClipPlayer` and `ClipSequence`.  
Includes property bindings for playback speed, looping, direction, frame offsets, flipping, rotation, scaling, and anchor points.  
Adds supporting services (`ClipService`) and models (`ClipFrame`, `ClipSequence`, `SpriteProperties`, `ClipProperties`) for handling sprite sheet animations.

## Related Issue
- Resolves #53

## Motivation and Context
UI developers need a reusable sprite control to display and animate sprite sheets efficiently in the UI framework.  
This addresses the lack of built-in sprite animation support and standardizes how sprite-based content is handled.

## How Has This Been Tested?
- Verified that the project compiles successfully

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.