### PR TITLE
Adding Demo Application Framework Integration

### DIFF
--- a/PhotonUI.Demo/Program.cs
+++ b/PhotonUI.Demo/Program.cs
@@ -1,8 +1,66 @@
-﻿partial class Program
+﻿using Microsoft.Extensions.DependencyInjection;
+using NucleusAF.Console.ViewModel;
+using PhotonUI.Components;
+using PhotonUI.Controls;
+using PhotonUI.Controls.Decorators;
+using PhotonUI.Interfaces.Services;
+using PhotonUI.Services;
+using PhotonUI.Services.Interpolators;
+using PhotonUI.Demo;
+using SDL3;
+
+partial class Program
 {
     static void Main(string[] args)
     {
-        MainArgsHandler(args);      
+        MainArgsHandler(args);
+
+        Window window = null!;
+        object view = null!;
+        object viewModel = null!;
+
+        Vacuum.Excite(
+            services =>
+            {
+                //services.AddSingleton<IProviderFontFamily, ProviderFontDejaVuSansMono>();
+                services.AddSingleton<IFontService, FontService>();
+                services.AddSingleton<ITextureService, TextureService>();
+                services.AddSingleton<IBindingService, BindingService>();
+                services.AddSingleton<IKeyBindingService, KeyBindingService>();
+                services.AddSingleton<IClipService, ClipService>();
+
+                services.AddSingleton<IInterpolator, IntInterpolator>();
+                services.AddSingleton<IInterpolator, FloatInterpolator>();
+                services.AddSingleton<IInterpolator, SDLColorInterpolator>();
+                services.AddSingleton<IInterpolatorService, InterpolatorService>();
+                services.AddSingleton<IAnimationBuilder, AnimationBuilder>();
+
+                services.AddTransient<MainView>();
+                services.AddTransient<MainViewModel>();
+                services.AddTransient<Window>();
+            },
+            provider =>
+            {
+                window = provider.GetRequiredService<Window>();
+                view = provider.GetRequiredService<MainView>();
+                viewModel = provider.GetRequiredService<MainViewModel>();
+
+                if (!SDL.Init(SDL.InitFlags.Video))
+                    throw new InvalidProgramException(SDL.GetError());
+
+                if (!TTF.Init())
+                    throw new InvalidProgramException(SDL.GetError());
+            }
+        );
+
+        if (window == null)
+            throw new NullReferenceException("Window instance == null after DI resolution.");
+
+        window.Name = "Window";
+        window.Child = (Border)view;
+        window.Child.DataContext = viewModel;
+
+        Vacuum.Emit(window);
     }
 
     #region PhotonUI.Demo: Argumentation

--- a/PhotonUI.Demo/Vacuum.cs
+++ b/PhotonUI.Demo/Vacuum.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using PhotonUI.Controls;
+using SDL3;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace PhotonUI.Demo
+{
+    public class Vacuum
+    {
+        public static void Excite(Action<IServiceCollection>? configure = null, Action<IServiceProvider>? ready = null)
+        {
+            ServiceCollection serviceCollection = new();
+
+            configure?.Invoke(serviceCollection);
+
+            IServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
+
+            ready?.Invoke(serviceProvider);
+        }
+        public static void Emit(Window window)
+        {
+            bool quit = false;
+
+            window.Initialize();
+
+            LoadDefaultWidowIcon(window);
+
+            while (!quit)
+            {
+                while (SDL.PollEvent(out SDL.Event e))
+                {
+                    window.Event(e);
+
+                    switch (e.Type)
+                    {
+                        case (uint)SDL.EventType.WindowResized:
+                            window.SetWindowSize(e.Window.Data1, e.Window.Data2);
+                            break;
+
+                        case (uint)SDL.EventType.KeyDown:
+                            {
+                                switch (e.Key.Key)
+                                {
+                                    case SDL.Keycode.PrintScreen:
+                                        window.GetScreenshot(Path.Combine(AppContext.BaseDirectory, "screenshot.png"));
+                                        break;
+
+                                    case SDL.Keycode.Tab:
+                                        if ((e.Key.Mod & SDL.Keymod.Shift) != 0)
+                                            window.TabStopBackward();
+                                        else
+                                            window.TabStopForward();
+                                        break;
+                                }
+                                break;
+                            }
+
+                        case (uint)SDL.EventType.Quit:
+                            quit = true;
+                            break;
+                    }
+                }
+
+                window.Tick();
+
+                SDL.Delay(1000 / 42);
+            }
+
+            if (window.Handle != IntPtr.Zero)
+                SDL.DestroyWindow(window.Handle);
+
+            SDL.Quit();
+        }
+
+        private static void LoadDefaultWidowIcon(Window window)
+        {
+            Stream? stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("PhotonUI.Demo.Assets.Images.photon.icon.png");
+
+            if (stream != null)
+            {
+                byte[] bytes;
+
+                using (MemoryStream ms = new())
+                {
+                    stream.CopyTo(ms);
+                    bytes = ms.ToArray();
+                }
+
+                GCHandle handle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+                try
+                {
+                    IntPtr ptr = handle.AddrOfPinnedObject();
+                    nuint size = (nuint)bytes.Length;
+
+                    IntPtr io = SDL.IOFromMem(ptr, size);
+                    IntPtr surface = Image.LoadIO(io, true);
+
+                    if (surface == IntPtr.Zero)
+                        throw new InvalidOperationException(SDL.GetError());
+
+                    SDL.SetWindowIcon(window.Handle, surface);
+                    SDL.DestroySurface(surface);
+                }
+                finally
+                {
+                    handle.Free();
+                }
+            }
+        }
+    }
+}

--- a/PhotonUI.Demo/ViewModels/MainViewModel.cs
+++ b/PhotonUI.Demo/ViewModels/MainViewModel.cs
@@ -1,0 +1,11 @@
+﻿using PhotonUI.Interfaces.Services;
+using PhotonUI.ViewModels;
+
+namespace NucleusAF.Console.ViewModel
+{
+    public partial class MainViewModel(IServiceProvider serviceProvider, IBindingService bindingService)
+        : ViewModelBase(serviceProvider, bindingService)
+    {
+
+    }
+}

--- a/PhotonUI.Demo/Views/MainView.cs
+++ b/PhotonUI.Demo/Views/MainView.cs
@@ -1,0 +1,41 @@
+﻿using PhotonUI.Controls;
+using PhotonUI.Controls.Content;
+using PhotonUI.Controls.Decorators;
+using PhotonUI.Controls.Input;
+using PhotonUI.Controls.Interaction;
+using PhotonUI.Controls.Layout;
+using PhotonUI.Controls.Viewport;
+using PhotonUI.Interfaces.Services;
+using PhotonUI.Models;
+using PhotonUI.Models.Properties;
+using SDL3;
+
+namespace PhotonUI.Demo
+{
+    public class MainView(IServiceProvider serviceProvider, IBindingService bindingService, IKeyBindingService keyBindingService, ITextureService textureService)
+        : Border(serviceProvider, bindingService, keyBindingService)
+    {
+        protected readonly ITextureService TexureService = textureService;
+
+        public override void OnInitialize(Window window)
+        {
+            this.TexureService.LoadEmbeddedSurface("PhotonUI.Demo.Assets.Images.sdl_logo.png", "sdl_logo");
+
+            this.Name = "MainView";
+            this.BackgroundColor = new SDL.Color() { A = 255, R = 51, G = 56, B = 63 };
+            this.HorizontalAlignment = HorizontalAlignment.Stretch;
+            this.VerticalAlignment = VerticalAlignment.Stretch;
+            this.Margin = new(10);
+            this.Padding = new(10);
+            this.BorderThickness = new(5);
+            this.BorderColors = new BorderColors(new SDL.Color() { A = 255, R = 112, G = 128, B = 144 });
+
+            TextBlock textBlock = Create<TextBlock>();
+            //textBlock.Text = "Welcome to PhotonUI";
+            textBlock.VerticalAlignment = VerticalAlignment.Center;
+            textBlock.HorizontalAlignment = HorizontalAlignment.Center;
+
+            this.Child = textBlock;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a demo application with structured DI, SDL3 window handling, and basic UI components. Includes `Vacuum` for service initialization and main loop, `MainView` and `MainViewModel` for UI and data context, and updates `Program.cs` to launch the demo.

## Related Issue

- Resolves #69

## Motivation and Context

Provides a reference implementation for framework developers to validate DI setup, SDL3 integration, and UI component wiring.

## How Has This Been Tested?

* Ensured the demo application compiles successfully.

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Asset change (adds or updates icons, templates, or other assets)
* [ ] Documentation change (adds or updates documentation)
* [ ] Plugin change (adds or updates a plugin)

## Checklist:

* [x] I have read the **CONTRIBUTING** document.
* [x] My change requires a change to the core logic.
  * [x] I have linked the project issue above.
* [ ] My change requires a change to the assets.
  * [ ] I have linked the asset issue above.
* [ ] My change requires a change to the documentation.
  * [ ] I have linked the documentation issue above.
* [ ] My change requires a change to a plugin.
  * [ ] I have linked the plugin issue above.