### PR TITLE
Adding Dynamic Window Initialization

### DIFF
--- a/PhotonUI.Demo/Vacuum.cs
+++ b/PhotonUI.Demo/Vacuum.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using PhotonUI.Controls;
+using PhotonUI.Models;
 using SDL3;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -22,7 +23,7 @@ namespace PhotonUI.Demo
         {
             bool quit = false;
 
-            window.Initialize();
+            window.Initialize("PhotonUI :: Demo", new Size(800,600), SDL.WindowFlags.Resizable);
 
             LoadDefaultWidowIcon(window);
 

--- a/PhotonUI/Controls/Window.cs
+++ b/PhotonUI/Controls/Window.cs
@@ -4,6 +4,7 @@ using PhotonUI.Events.Framework;
 using PhotonUI.Events.Platform;
 using PhotonUI.Extensions;
 using PhotonUI.Interfaces.Services;
+using PhotonUI.Models;
 using SDL3;
 using System.Linq.Expressions;
 
@@ -52,6 +53,10 @@ namespace PhotonUI.Controls
 
         #region Window: Platform
 
+        public string DefaultTitle { get; protected set; } = "PhotonUI";
+        public Size DefaultSize { get; protected set; } = new Size(800, 600);
+        public SDL.WindowFlags DefaultFlags { get; protected set; } = SDL.WindowFlags.Resizable;
+
         public IntPtr Handle { get; protected set; }
         public IntPtr Renderer { get; protected set; }
 
@@ -74,8 +79,14 @@ namespace PhotonUI.Controls
             return logical;
         }
 
-        public virtual void Initialize()
-            => this.FrameworkInitialize(this);
+        public virtual void Initialize(string title, Size size, SDL.WindowFlags flags)
+        {
+            this.DefaultTitle = title;
+            this.DefaultSize = size;
+            this.DefaultFlags = flags;
+
+            this.FrameworkInitialize(this);
+        }
         public virtual void Tick()
         {
             this.ApplyTick();
@@ -694,8 +705,11 @@ namespace PhotonUI.Controls
 
             if (window.Mode == WindowMode.Tangible)
             {
-                //TODO: This needs to be replaced with argumentation or assume this is setup before hand.
-                window.Handle = SDL.CreateWindow("PhotonUI :: Demo", 800, 600, SDL.WindowFlags.Resizable);
+                window.Handle = SDL.CreateWindow(
+                    window.DefaultTitle,
+                    (int)window.DefaultSize.Width,
+                    (int)window.DefaultSize.Height,
+                    window.DefaultFlags);
 
                 if (!window.HasTangibleWindow)
                 {


### PR DESCRIPTION
## Description

Introduces the ability to configure the window’s title, size, and SDL flags during initialization via a new `Initialize(string title, Size size, SDL.WindowFlags flags)` method. The `FrameworkInitialize` method now uses these properties when creating the SDL window, enabling dynamic and flexible window creation.

## Related Issue

- Resolves #73

## Motivation and Context

Previously, window initialization relied on hardcoded title, size, and flags values, limiting flexibility. This change allows developers to provide meaningful titles, adjust initial window size, and specify SDL window flags, improving usability and customization for PhotonUI-based applications and demos.

## How Has This Been Tested?

Tested by running the demo application with the new `Initialize` method. Verified that the SDL window correctly uses the provided title, size, and flags. The demo displayed `"PhotonUI :: Demo"` at `800x600` with a resizable window, and no errors occurred during initialization or rendering.

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Asset change (adds or updates icons, templates, or other assets)
* [ ] Documentation change (adds or updates documentation)
* [ ] Plugin change (adds or updates a plugin)

## Checklist:

* [x] I have read the **CONTRIBUTING** document.
* [x] My change requires a change to the core logic.
  * [x] I have linked the project issue above.
* [ ] My change requires a change to the assets.
  * [ ] I have linked the asset issue above.
* [ ] My change requires a change to the documentation.
  * [ ] I have linked the documentation issue above.
* [ ] My change requires a change to a plugin.
  * [ ] I have linked the plugin issue above.