### PR TITLE
Fixed Window first frame misses full measure/arrange

### DIFF
--- a/PhotonUI/Controls/Window.cs
+++ b/PhotonUI/Controls/Window.cs
@@ -56,6 +56,7 @@ namespace PhotonUI.Controls
         public string DefaultTitle { get; protected set; } = "PhotonUI";
         public Size DefaultSize { get; protected set; } = new Size(800, 600);
         public SDL.WindowFlags DefaultFlags { get; protected set; } = SDL.WindowFlags.Resizable;
+        public bool SuppressRendering { get; set; } = false;
 
         public IntPtr Handle { get; protected set; }
         public IntPtr Renderer { get; protected set; }
@@ -408,6 +409,9 @@ namespace PhotonUI.Controls
 
         protected bool NeedsRendering()
         {
+            if (this.SuppressRendering)
+                return false;
+
             bool needsRender = false;
 
             this.TunnelControls((c) =>
@@ -740,6 +744,16 @@ namespace PhotonUI.Controls
             window.IsInitialized = true;
 
             window.Child?.FrameworkInitialize(window);
+
+            this.SuppressRendering = true;
+
+            window.Tick();
+
+            this.SuppressRendering = false;
+
+            window.RequestMeasure();
+            window.RequestArrange();
+            window.RequestRender();
         }
 
         #endregion


### PR DESCRIPTION
## Description

This pull request addresses a subtle bug in the window initialization lifecycle. On the first frame, **any window** (tangible or logical) does not fully propagate intrinsic, measure, and arrange passes across its control hierarchy. As a result, the first frame is only partially initialized — child controls may have incorrect sizes or positions, and layout-dependent behaviors may not trigger.  

Previously, the first frame of any window was partially initialized because the layout lifecycle did not fully propagate. This PR ensures a two-pass tick during initialization: the first pass suppresses rendering to fully seed intrinsic, measure, and arrange values; the second pass renders normally for the first visible frame.

Key changes include:

* Introduced `SuppressRendering` flag to skip rendering during the first artificial tick.
* Updated `FrameworkInitialize` to perform a full lifecycle tick with rendering suppressed before normal rendering begins.
* Ensures that intrinsic, measure, and arrange requests propagate fully before the first visible frame.

## Related Issue

- Fixes #75

## Motivation and Context

The problem affects any retained-mode window, causing inconsistent first-frame layouts, especially in complex UIs with nested controls. By forcing a second pass internally while suppressing rendering, the layout is fully realized before any visible output, eliminating flicker, size misalignments, and partially-initialized controls.

This is critical for:

* Predictable UI startup behavior.
* Maintaining correct retained-mode lifecycle semantics.

## How Has This Been Tested?

* Created windows with nested child controls of varying intrinsic sizes.
* Verified that first frame fully respects layout rules without visual artifacts.
* Enabled and disabled `SuppressRendering` to confirm that the suppression works correctly without affecting subsequent ticks.

Environment:

* Windows 11
* .NET 8.0
* SDL3
* PhotonUI (pre-release)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.