### PR TITLE
 Centralized Window Initialization

### DIFF
--- a/PhotonUI.Demo/Program.cs
+++ b/PhotonUI.Demo/Program.cs
@@ -6,9 +6,12 @@ using PhotonUI.Demo;
 using PhotonUI.Demo.ViewModels;
 using PhotonUI.Demo.Views;
 using PhotonUI.Interfaces.Services;
+using PhotonUI.Models;
 using PhotonUI.Services;
 using PhotonUI.Services.Interpolators;
 using SDL3;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 partial class Program
 {
@@ -61,6 +64,9 @@ partial class Program
         window.Name = "Window";
         window.Child = (Border)view;
         window.Child.DataContext = viewModel;
+        window.Initialize("PhotonUI :: Demo", new Size(800, 600), SDL.WindowFlags.Resizable);
+
+        LoadDefaultWidowIcon(window);
 
         Vacuum.Emit(window);
     }
@@ -71,6 +77,46 @@ partial class Program
     {
         foreach (string arg in args)
             if (string.IsNullOrEmpty(arg)) { }
+    }
+
+    #endregion
+
+    #region PhotonUI.Demo: Window Customization
+
+    private static void LoadDefaultWidowIcon(Window window)
+    {
+        Stream? stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("PhotonUI.Demo.Assets.Images.photon.icon.png");
+
+        if (stream != null)
+        {
+            byte[] bytes;
+
+            using (MemoryStream ms = new())
+            {
+                stream.CopyTo(ms);
+                bytes = ms.ToArray();
+            }
+
+            GCHandle handle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+            try
+            {
+                IntPtr ptr = handle.AddrOfPinnedObject();
+                nuint size = (nuint)bytes.Length;
+
+                IntPtr io = SDL.IOFromMem(ptr, size);
+                IntPtr surface = Image.LoadIO(io, true);
+
+                if (surface == IntPtr.Zero)
+                    throw new InvalidOperationException(SDL.GetError());
+
+                SDL.SetWindowIcon(window.Handle, surface);
+                SDL.DestroySurface(surface);
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
     }
 
     #endregion

--- a/PhotonUI.Demo/Vacuum.cs
+++ b/PhotonUI.Demo/Vacuum.cs
@@ -1,9 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using PhotonUI.Controls;
-using PhotonUI.Models;
 using SDL3;
-using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace PhotonUI.Demo
 {
@@ -22,10 +19,6 @@ namespace PhotonUI.Demo
         public static void Emit(Window window)
         {
             bool quit = false;
-
-            window.Initialize("PhotonUI :: Demo", new Size(800,600), SDL.WindowFlags.Resizable);
-
-            LoadDefaultWidowIcon(window);
 
             while (!quit)
             {
@@ -72,42 +65,6 @@ namespace PhotonUI.Demo
                 SDL.DestroyWindow(window.Handle);
 
             SDL.Quit();
-        }
-
-        private static void LoadDefaultWidowIcon(Window window)
-        {
-            Stream? stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("PhotonUI.Demo.Assets.Images.photon.icon.png");
-
-            if (stream != null)
-            {
-                byte[] bytes;
-
-                using (MemoryStream ms = new())
-                {
-                    stream.CopyTo(ms);
-                    bytes = ms.ToArray();
-                }
-
-                GCHandle handle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-                try
-                {
-                    IntPtr ptr = handle.AddrOfPinnedObject();
-                    nuint size = (nuint)bytes.Length;
-
-                    IntPtr io = SDL.IOFromMem(ptr, size);
-                    IntPtr surface = Image.LoadIO(io, true);
-
-                    if (surface == IntPtr.Zero)
-                        throw new InvalidOperationException(SDL.GetError());
-
-                    SDL.SetWindowIcon(window.Handle, surface);
-                    SDL.DestroySurface(surface);
-                }
-                finally
-                {
-                    handle.Free();
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
## Description
This PR refactors the window setup in the PhotonUI demo. All window initialization and customization (title, size, flags, default icon) are now centralized in `Program.cs`. `Vacuum.cs` has been simplified to focus purely on the main SDL loop and dependency injection setup, removing window-specific logic. This improves code readability, maintainability, and separation of concerns.

## Related Issue
- Resolves #77

## Motivation and Context
Currently, window customization is split across multiple files, making it harder to maintain or extend. Centralizing it in `Program.cs` consolidates all setup logic in one place, while `Vacuum.cs` remains reusable for any generic main loop, making the demo easier to understand and modify.

## How Has This Been Tested?
- Verified that the demo window still launches correctly with the proper title, size, and icon.
- Ensured the SDL main loop in `Vacuum.cs` functions as expected with no regressions.
- Tested on Windows 10 with SDL3 bindings; no errors or warnings in console.

## Screenshots (if appropriate):
Not applicable—this is a code refactor with no visible UI change aside from proper icon display.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.