### PR TITLE
Fixing layout inconsistencies

### DIFF
--- a/PhotonUI/Controls/Canvas.cs
+++ b/PhotonUI/Controls/Canvas.cs
@@ -129,54 +129,21 @@ namespace PhotonUI.Controls
         {
             foreach (Control child in this.Children)
             {
-                // Calculate available space for the child after padding
-                SDL.FRect containerRect = this.DrawRect.Deflate(this.PaddingExtent);
+                Size stretchedSize = Photon.GetStretchedSize(this, child);
 
-                // Stretch within remaining space after total offsets (X/Y + margins)
-                float stretchedW = Photon.GetStretchedWidth(
-                    child.HorizontalAlignment,
-                    child.IntrinsicSize.Width,
-                    containerRect.W,
-                    child.X + child.MarginExtent.Horizontal);
+                child.DrawRect.W = stretchedSize.Width;
+                child.DrawRect.H = stretchedSize.Height;
 
-                float stretchedH = Photon.GetStretchedHeight(
-                    child.VerticalAlignment,
-                    child.IntrinsicSize.Height,
-                    containerRect.H,
-                    child.Y + child.MarginExtent.Vertical);
-
-                // Set child's content size within min/max bounds (DrawRect excludes margins)
-                child.DrawRect.W = Math.Clamp(stretchedW, child.MinWidth, child.MaxWidth);
-                child.DrawRect.H = Math.Clamp(stretchedH, child.MinHeight, child.MaxHeight);
+                child.OnMeasure(window);
             }
         }
         public override void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
-            // Set control's position, including margins and offsets
-            this.DrawRect.X = anchor.X + this.MarginExtent.Left + this.X;
-            this.DrawRect.Y = anchor.Y + this.MarginExtent.Top + this.Y;
+            base.FrameworkArrange(window, anchor);
 
             foreach (Control child in this.Children)
             {
-                // Child's base position: parent content 
-                float childX = this.DrawRect.X + this.PaddingExtent.Left;
-                float childY = this.DrawRect.Y + this.PaddingExtent.Top;
-
-                // Calculate child's alignment position within parent content area
-                float horizontalPosition = Photon.GetHorizontalAlignment(
-                    child.HorizontalAlignment,
-                    childX,
-                    child.DrawRect.W,
-                    this.DrawRect.W);
-
-                float verticalPosition = Photon.GetVerticalAlignment(
-                    child.VerticalAlignment,
-                    childY,
-                    child.DrawRect.H,
-                    this.DrawRect.H);
-
-                // Define final anchor point for child
-                SDL.FPoint childAnchor = new() { X = horizontalPosition, Y = verticalPosition };
+                SDL.FPoint childAnchor = Photon.GetRelativePosition(this, child);
 
                 // Arrange child based on computed anchor point
                 child.OnArrange(window, childAnchor);

--- a/PhotonUI/Controls/Content/TextBlock.cs
+++ b/PhotonUI/Controls/Content/TextBlock.cs
@@ -161,7 +161,8 @@ namespace PhotonUI.Controls.Content
         }
         public override void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
-            base.FrameworkArrange(window, anchor);
+            this.DrawRect.X = anchor.X + this.X;
+            this.DrawRect.Y = anchor.Y + this.Y;
 
             this.BuildLineDataCache(this.Text, this.Font, this.TextWrapType, this.ScrollbarViewport.W);
 

--- a/PhotonUI/Controls/Control.cs
+++ b/PhotonUI/Controls/Control.cs
@@ -354,9 +354,8 @@ namespace PhotonUI.Controls
         public virtual void FrameworkMeasure(Window window) { }
         public virtual void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
-            // Update our location by extending to the margins
-            this.DrawRect.X = anchor.X + this.MarginExtent.Left + this.X;
-            this.DrawRect.Y = anchor.Y + this.MarginExtent.Top + this.Y;
+            this.DrawRect.X = anchor.X + this.X;
+            this.DrawRect.Y = anchor.Y + this.Y;
         }
         public virtual void FrameworkLateTick(Window window) { }
         public virtual void FrameworkRender(Window window, SDL.Rect? clipRect)

--- a/PhotonUI/Controls/Input/TextInput.cs
+++ b/PhotonUI/Controls/Input/TextInput.cs
@@ -123,8 +123,6 @@ namespace PhotonUI.Controls.Input
         {
             if (this.GrowsWithInput)
             {
-                Size intrinsic = this.IntrinsicSize;
-
                 float height = Photon.GetControlLinePixelHeight(this.LineDataCache);
                 float clampedHeight = Math.Clamp(height, this.MinHeight, this.MaxHeight);
 

--- a/PhotonUI/Controls/Layout/StackBlock.cs
+++ b/PhotonUI/Controls/Layout/StackBlock.cs
@@ -2,6 +2,7 @@
 using PhotonUI.Extensions;
 using PhotonUI.Interfaces;
 using PhotonUI.Interfaces.Services;
+using PhotonUI.Models;
 using PhotonUI.Models.Properties;
 using SDL3;
 using System.ComponentModel;
@@ -12,7 +13,7 @@ namespace PhotonUI.Controls.Layout
         : Canvas(serviceProvider, bindingService, keyBindingService), IStackProperties
     {
         [ObservableProperty] private Orientation stackOrientation = StackProperties.Default.StackOrientation;
-        [ObservableProperty] private StackFillType stackFillType = StackProperties.Default.StackFillType;
+        [ObservableProperty] private float spacing = StackProperties.Default.Spacing;
 
         #region StackPanel: Framework
 
@@ -33,140 +34,107 @@ namespace PhotonUI.Controls.Layout
             }
         }
 
+        public override void FrameworkIntrinsic(Window window, Size content)
+        {
+            bool isHorizontal = this.StackOrientation == Orientation.Horizontal;
+
+            float totalStackSize = 0f;
+            float maxCrossSize = 0f;
+
+            foreach (Control child in this.Children)
+            {
+                if (child == null) continue;
+
+                Size childContent = content.Deflate(child.PaddingExtent);
+
+                child.OnIntrinsic(window, childContent);
+
+                float stackSize = isHorizontal ? child.IntrinsicSize.Width : child.IntrinsicSize.Height;
+                float crossSize = isHorizontal ? child.IntrinsicSize.Height : child.IntrinsicSize.Width;
+                float stackMargin = isHorizontal ? child.MarginExtent.Horizontal : child.MarginExtent.Vertical;
+
+                totalStackSize += stackSize + stackMargin + this.Spacing;
+                maxCrossSize = Math.Max(maxCrossSize, crossSize);
+            }
+
+            totalStackSize -= this.Spacing;
+
+            Size stackContent = isHorizontal
+                ? new Size(totalStackSize, maxCrossSize)
+                : new Size(maxCrossSize, totalStackSize);
+
+            this.IntrinsicSize = Photon.GetMinimumSize(this, stackContent);
+        }
         public override void FrameworkMeasure(Window window)
         {
-            SDL.FRect contentRect = this.DrawRect.Deflate(this.PaddingExtent);
-
             bool isHorizontal = this.StackOrientation == Orientation.Horizontal;
 
             foreach (Control child in this.Children)
             {
                 if (child == null) continue;
 
-                float stackSize = isHorizontal ? child.IntrinsicSize.Width : child.IntrinsicSize.Height;
+                bool allowStretchW = !isHorizontal;
+                bool allowStretchH = isHorizontal;
 
-                float crossAvailable = isHorizontal ? contentRect.H : contentRect.W;
-
-                float crossOffset = isHorizontal
-                    ? child.Y + child.MarginExtent.Vertical
-                    : child.X + child.MarginExtent.Horizontal;
-
-                float crossSize = isHorizontal
-                    ? Photon.GetStretchedHeight(child.VerticalAlignment, child.IntrinsicSize.Height, crossAvailable, crossOffset)
-                    : Photon.GetStretchedWidth(child.HorizontalAlignment, child.IntrinsicSize.Width, crossAvailable, crossOffset);
+                Size stretched = Photon.GetStretchedSize(this, child, allowStretchW, allowStretchH);
 
                 if (isHorizontal)
                 {
-                    child.DrawRect.W = Math.Clamp(stackSize, child.MinWidth, child.MaxWidth);
-                    child.DrawRect.H = Math.Clamp(crossSize, child.MinHeight, child.MaxHeight);
+                    child.DrawRect.W = child.IntrinsicSize.Width;
+                    child.DrawRect.H = stretched.Height;
                 }
                 else
                 {
-                    child.DrawRect.W = Math.Clamp(crossSize, child.MinWidth, child.MaxWidth);
-                    child.DrawRect.H = Math.Clamp(stackSize, child.MinHeight, child.MaxHeight);
-                }
-            }
-
-            int validChildCount = this.Children.Count(c => c != null);
-
-            float totalAvailableSize = isHorizontal
-                ? (contentRect.W)
-                : (contentRect.H);
-
-            float totalContentSize = 0f;
-
-            foreach (Control child in this.Children)
-            {
-                if (child == null) continue;
-
-                float stackSize = isHorizontal ? child.DrawRect.W : child.DrawRect.H;
-                float stackMargin = isHorizontal
-                    ? child.MarginExtent.Horizontal
-                    : child.MarginExtent.Vertical;
-
-                totalContentSize += stackSize + stackMargin;
-            }
-
-            int index = 0;
-            float dummyOffset = 0f;
-
-            foreach (Control child in this.Children)
-            {
-                if (child == null)
-                {
-                    index++;
-
-                    continue;
+                    child.DrawRect.W = stretched.Width;
+                    child.DrawRect.H = child.IntrinsicSize.Height;
                 }
 
-                switch (this.StackFillType)
-                {
-                    case StackFillType.None:
-                        dummyOffset += this.MeasureStackItemNone(child);
-                        break;
-
-                    case StackFillType.Equal:
-                        dummyOffset += this.MeasureStackItemEqual(child, totalAvailableSize, totalContentSize, validChildCount);
-                        break;
-
-                    case StackFillType.First:
-                        dummyOffset += this.MeasureStackItemFillIndex(child, totalAvailableSize, totalContentSize, validChildCount, 0);
-                        break;
-
-                    case StackFillType.Last:
-                        dummyOffset += this.MeasureStackItemFillIndex(child, totalAvailableSize, totalContentSize, validChildCount, validChildCount - 1);
-                        break;
-                }
-
-                index++;
+                child.OnMeasure(window);
             }
         }
         public override void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
-            this.DrawRect.X = anchor.X + this.MarginExtent.Left + this.X;
-            this.DrawRect.Y = anchor.Y + this.MarginExtent.Top + this.Y;
+            this.DrawRect.X = anchor.X + this.X;
+            this.DrawRect.Y = anchor.Y + this.Y;
 
-            SDL.FPoint contentStart = new()
-            {
-                X = this.DrawRect.X + this.PaddingExtent.Left,
-                Y = this.DrawRect.Y + this.PaddingExtent.Top
-            };
-
+            bool isHorizontal = this.StackOrientation == Orientation.Horizontal;
             float offset = 0f;
+
+            SDL.FRect contentRect = this.DrawRect.Deflate(this.PaddingExtent);
 
             foreach (Control child in this.Children)
             {
                 if (child == null) continue;
 
-                float horizontalPosition = 0;
-                float verticalPosition = 0;
+                float crossX = contentRect.X + child.MarginExtent.Left;
+                float crossY = contentRect.Y + child.MarginExtent.Top;
 
-                switch (this.StackFillType)
+                if (isHorizontal && child.VerticalAlignment != VerticalAlignment.Top)
                 {
-                    case StackFillType.None:
-                        offset = this.ArrangeStackItemNone(child, contentStart, offset, out horizontalPosition, out verticalPosition);
-                        break;
-
-                    case StackFillType.Equal:
-                        offset = this.ArrangeStackItemEqual(child, contentStart, offset, out horizontalPosition, out verticalPosition);
-                        break;
-
-                    case StackFillType.First:
-                        offset = this.ArrangeStackItemFillIndex(child, contentStart, offset, out horizontalPosition, out verticalPosition);
-                        break;
-
-                    case StackFillType.Last:
-                        offset = this.ArrangeStackItemFillIndex(child, contentStart, offset, out horizontalPosition, out verticalPosition);
-                        break;
+                    if (child.VerticalAlignment == VerticalAlignment.Center)
+                        crossY += (contentRect.H - child.DrawRect.H) / 2;
+                    else if (child.VerticalAlignment == VerticalAlignment.Bottom)
+                        crossY += contentRect.H - child.DrawRect.H - child.MarginExtent.Bottom;
+                }
+                else if (!isHorizontal && child.HorizontalAlignment != HorizontalAlignment.Left)
+                {
+                    if (child.HorizontalAlignment == HorizontalAlignment.Center)
+                        crossX += (contentRect.W - child.DrawRect.W) / 2;
+                    else if (child.HorizontalAlignment == HorizontalAlignment.Right)
+                        crossX += contentRect.W - child.DrawRect.W - child.MarginExtent.Right;
                 }
 
                 SDL.FPoint childAnchor = new()
                 {
-                    X = horizontalPosition,
-                    Y = verticalPosition
+                    X = crossX + (isHorizontal ? offset : 0),
+                    Y = crossY + (isHorizontal ? 0 : offset)
                 };
 
                 child.OnArrange(window, childAnchor);
+
+                offset += (isHorizontal ? child.DrawRect.W : child.DrawRect.H) +
+                          (isHorizontal ? child.MarginExtent.Horizontal : child.MarginExtent.Vertical) +
+                          this.Spacing;
             }
         }
 
@@ -191,7 +159,6 @@ namespace PhotonUI.Controls.Layout
             switch (e.PropertyName)
             {
                 case nameof(this.StackOrientation):
-                case nameof(this.StackFillType):
                     invalidateMeasure = true;
                     invalidateLayout = true;
                     invalidateRender = true;
@@ -206,155 +173,6 @@ namespace PhotonUI.Controls.Layout
 
             if (invalidateRender)
                 this.RequestRender();
-        }
-
-        #endregion
-
-        #region StackPanel: Helpers
-
-        private float MeasureStackItemNone(Control child)
-        {
-            bool isHorizontal = this.StackOrientation == Orientation.Horizontal;
-
-            float childStackSize = isHorizontal ? child.DrawRect.W : child.DrawRect.H;
-            float childStackMargin = isHorizontal
-                ? child.MarginExtent.Horizontal
-                : child.MarginExtent.Vertical;
-
-            return childStackSize + childStackMargin;
-        }
-        private float MeasureStackItemEqual(Control child, float totalAvailableSize, float totalContentSize, int validChildCount)
-        {
-            bool isHorizontal = this.StackOrientation == Orientation.Horizontal;
-
-            float extraPerChild = validChildCount > 0
-                ? (totalAvailableSize - totalContentSize) / validChildCount
-                : 0;
-
-            float childNaturalSize = isHorizontal ? child.DrawRect.W : child.DrawRect.H;
-            float targetStackSize = childNaturalSize + extraPerChild;
-
-            if (isHorizontal)
-            {
-                child.DrawRect.W = Math.Clamp(targetStackSize, child.MinWidth, child.MaxWidth);
-            }
-            else
-            {
-                child.DrawRect.H = Math.Clamp(targetStackSize, child.MinHeight, child.MaxHeight);
-            }
-
-            float childStackSize = isHorizontal ? child.DrawRect.W : child.DrawRect.H;
-            float childStackMargin = isHorizontal
-                ? child.MarginExtent.Horizontal
-                : child.MarginExtent.Vertical;
-
-            return childStackSize + childStackMargin;
-        }
-        private float MeasureStackItemFillIndex(Control child, float totalAvailableSize, float totalContentSize, int validChildCount, int targetIndex)
-        {
-            bool isHorizontal = this.StackOrientation == Orientation.Horizontal;
-
-            float extraForTarget = validChildCount > 0
-                ? (totalAvailableSize - totalContentSize)
-                : 0;
-
-            int childIndex = this.Children.IndexOf(child);
-
-            if (childIndex == targetIndex)
-            {
-                float childNaturalSize = isHorizontal ? child.DrawRect.W : child.DrawRect.H;
-                float targetStackSize = childNaturalSize + extraForTarget;
-
-                if (isHorizontal)
-                {
-                    child.DrawRect.W = Math.Clamp(targetStackSize, child.MinWidth, child.MaxWidth);
-                }
-                else
-                {
-                    child.DrawRect.H = Math.Clamp(targetStackSize, child.MinHeight, child.MaxHeight);
-                }
-            }
-
-            float childStackSize = isHorizontal ? child.DrawRect.W : child.DrawRect.H;
-            float childStackMargin = isHorizontal
-                ? child.MarginExtent.Horizontal
-                : child.MarginExtent.Vertical;
-
-            return childStackSize + childStackMargin;
-        }
-
-        private float ArrangeStackItemNone(Control child, SDL.FPoint contentStart, float offset, out float horizontalPosition, out float verticalPosition)
-        {
-            bool isHorizontal = this.StackOrientation == Orientation.Horizontal;
-
-            float baseX = isHorizontal ? contentStart.X + offset : contentStart.X;
-            float baseY = !isHorizontal ? contentStart.Y + offset : contentStart.Y;
-
-            float containerW = this.DrawRect.W - this.PaddingExtent.Horizontal;
-            float containerH = this.DrawRect.H - this.PaddingExtent.Vertical;
-
-            horizontalPosition = Photon.GetHorizontalAlignment(
-                child.HorizontalAlignment, baseX, child.DrawRect.W, containerW);
-
-            verticalPosition = Photon.GetVerticalAlignment(
-                child.VerticalAlignment, baseY, child.DrawRect.H, containerH);
-
-            float childStackSize = isHorizontal ? child.DrawRect.W : child.DrawRect.H;
-            float childStackMargin = isHorizontal
-                ? child.MarginExtent.Horizontal
-                : child.MarginExtent.Vertical;
-
-            offset += childStackSize + childStackMargin;
-
-            return offset;
-        }
-        private float ArrangeStackItemEqual(Control child, SDL.FPoint contentStart, float offset, out float horizontalPosition, out float verticalPosition)
-        {
-            bool isHorizontal = this.StackOrientation == Orientation.Horizontal;
-
-            float baseX = isHorizontal ? contentStart.X + offset : contentStart.X;
-            float baseY = !isHorizontal ? contentStart.Y + offset : contentStart.Y;
-
-            float containerW = this.DrawRect.W - this.PaddingExtent.Horizontal;
-            float containerH = this.DrawRect.H - this.PaddingExtent.Vertical;
-
-            horizontalPosition = Photon.GetHorizontalAlignment(
-                child.HorizontalAlignment, baseX, child.DrawRect.W, containerW);
-            verticalPosition = Photon.GetVerticalAlignment(
-                child.VerticalAlignment, baseY, child.DrawRect.H, containerH);
-
-            float childStackSize = isHorizontal ? child.DrawRect.W : child.DrawRect.H;
-            float childStackMargin = isHorizontal
-                ? child.MarginExtent.Horizontal
-                : child.MarginExtent.Vertical;
-
-            offset += childStackSize + childStackMargin;
-
-            return offset;
-        }
-        private float ArrangeStackItemFillIndex(Control child, SDL.FPoint contentStart, float offset, out float horizontalPosition, out float verticalPosition)
-        {
-            bool isHorizontal = this.StackOrientation == Orientation.Horizontal;
-
-            float baseX = isHorizontal ? contentStart.X + offset : contentStart.X;
-            float baseY = !isHorizontal ? contentStart.Y + offset : contentStart.Y;
-
-            float containerW = this.DrawRect.W - this.PaddingExtent.Horizontal;
-            float containerH = this.DrawRect.H - this.PaddingExtent.Vertical;
-
-            horizontalPosition = Photon.GetHorizontalAlignment(
-                child.HorizontalAlignment, baseX, child.DrawRect.W, containerW);
-            verticalPosition = Photon.GetVerticalAlignment(
-                child.VerticalAlignment, baseY, child.DrawRect.H, containerH);
-
-            float childStackSize = isHorizontal ? child.DrawRect.W : child.DrawRect.H;
-            float childStackMargin = isHorizontal
-                ? child.MarginExtent.Horizontal
-                : child.MarginExtent.Vertical;
-
-            offset += childStackSize + childStackMargin;
-
-            return offset;
         }
 
         #endregion

--- a/PhotonUI/Controls/Presenter.cs
+++ b/PhotonUI/Controls/Presenter.cs
@@ -76,7 +76,7 @@ namespace PhotonUI.Controls
             if (this.Child != null)
             {
                 // Adjust content size for child's margins and padding
-                Size childContent = content.Deflate(this.Child.MarginExtent).Deflate(this.Child.PaddingExtent);
+                Size childContent = content.Deflate(this.PaddingExtent).Deflate(this.Child.MarginExtent);
 
                 // Get the child's intrinsic size
                 this.Child.OnIntrinsic(window, childContent);
@@ -92,57 +92,21 @@ namespace PhotonUI.Controls
         {
             if (this.Child != null)
             {
-                // Get available space for child after padding
-                SDL.FRect containerRect = this.DrawRect.Deflate(this.PaddingExtent);
+                Size stretchedSize = Photon.GetStretchedSize(this, this.Child);
 
-                // Stretch within remaining space after total offsets (X + margins)
-                float stretchedW = Photon.GetStretchedWidth(
-                    this.Child.HorizontalAlignment,
-                    this.Child.IntrinsicSize.Width,
-                    containerRect.W,
-                    this.Child.X + this.Child.MarginExtent.Horizontal);
+                this.Child.DrawRect.W = stretchedSize.Width;
+                this.Child.DrawRect.H = stretchedSize.Height;
 
-                float stretchedH = Photon.GetStretchedHeight(
-                    this.Child.VerticalAlignment,
-                    this.Child.IntrinsicSize.Height,
-                    containerRect.H,
-                    this.Child.Y + this.Child.MarginExtent.Vertical);
-
-                // Set child's content size within min/max bounds
-                this.Child.DrawRect.W = Math.Clamp(stretchedW, this.Child.MinWidth, this.Child.MaxWidth);
-                this.Child.DrawRect.H = Math.Clamp(stretchedH, this.Child.MinHeight, this.Child.MaxHeight);
+                this.Child.OnMeasure(window);
             }
         }
         public override void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
-            // Set position based on anchor and margins
-            this.DrawRect.X = anchor.X + this.MarginExtent.Left + this.X;
-            this.DrawRect.Y = anchor.Y + this.MarginExtent.Top + this.Y;
+            base.FrameworkArrange(window, anchor);
 
             if (this.Child != null)
             {
-                // Adjust child's position by padding
-                float childX = this.DrawRect.X + this.PaddingExtent.Left;
-                float childY = this.DrawRect.Y + this.PaddingExtent.Top;
-
-                // Calculate horizontal alignment position for child
-                float horizontalPosition =
-                    Photon.GetHorizontalAlignment(
-                        this.Child.HorizontalAlignment,
-                        childX,
-                        this.Child.DrawRect.W,
-                        this.DrawRect.W);
-
-                // Calculate vertical alignment position for child
-                float verticalPosition =
-                    Photon.GetVerticalAlignment(
-                        this.Child.VerticalAlignment,
-                        childY,
-                        this.Child.DrawRect.H,
-                        this.DrawRect.H);
-
-                // Define final anchor point for child
-                SDL.FPoint childAnchor = new() { X = horizontalPosition, Y = verticalPosition };
+                SDL.FPoint childAnchor = Photon.GetRelativePosition(this, this.Child);
 
                 // Arrange child based on computed anchor point
                 this.Child.OnArrange(window, childAnchor);

--- a/PhotonUI/Controls/Viewport/ScrollBlock.cs
+++ b/PhotonUI/Controls/Viewport/ScrollBlock.cs
@@ -16,7 +16,7 @@ namespace PhotonUI.Controls.Viewport
     {
         protected ScrollbarBehavior<ScrollBlock> ScrollbarBehavior;
 
-        #region ScrollBox: Style Properties
+        #region ScrollBlock: Style Properties
 
         [ObservableProperty] private ScrollViewportAnchor scrollViewportAnchor = ScrollProperties.Default.ScrollViewportAnchor;
         [ObservableProperty] private ScrollDirection scrollDirection = ScrollProperties.Default.ScrollDirection;
@@ -44,7 +44,7 @@ namespace PhotonUI.Controls.Viewport
             this.ScrollbarBehavior = new(this);
         }
 
-        #region ScrollBox: Scrollbar Behavior
+        #region ScrollBlock: Scrollbar Behavior
 
         protected virtual SDL.FRect ScrollbarViewport
         {
@@ -70,7 +70,7 @@ namespace PhotonUI.Controls.Viewport
 
         #endregion
 
-        #region ScrollBox: Framework
+        #region ScrollBlock: Framework
 
         public override void ApplyStyles(params IStyleProperties[] properties)
         {
@@ -89,12 +89,30 @@ namespace PhotonUI.Controls.Viewport
             }
         }
 
+        public override void RequestRender(bool invalidate = true)
+        {
+            this.IsRenderDirty = true;
+            this.ScrollbarBehavior.RequestRender();
+
+            if (invalidate)
+                Photon.InvalidateRenderChain(this);
+        }
+        public virtual void RequestRenderWithFlags(bool scrollbarDirty = false, bool invalidate = true)
+        {
+            this.IsRenderDirty = true;
+
+            if (scrollbarDirty == true)
+                this.ScrollbarBehavior.RequestRender();
+
+            if (invalidate)
+                Photon.InvalidateRenderChain(this);
+        }
+
         public override void FrameworkIntrinsic(Window window, Size content)
         {
             if (this.Child != null)
             {
-                // Adjust content size for child's margins and padding
-                Size childContent = content.Deflate(this.Child.MarginExtent).Deflate(this.Child.PaddingExtent);
+                Size childContent = content.Deflate(this.PaddingExtent).Deflate(this.Child.MarginExtent);
 
                 // Get the child's intrinsic size
                 this.Child.OnIntrinsic(window, childContent);
@@ -105,17 +123,20 @@ namespace PhotonUI.Controls.Viewport
         }
         public override void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
-            base.FrameworkArrange(window, anchor);
+            this.DrawRect.X = anchor.X + this.X;
+            this.DrawRect.Y = anchor.Y + this.Y;
 
             if (this.Child != null)
             {
-                this.ScrollX = Photon.ApplyHorizontalScroll(this.Child, this.ScrollX, this.ScrollbarViewport);
-                this.ScrollY = Photon.ApplyVerticalScroll(this.Child, this.ScrollY, this.ScrollbarViewport);
+                this.ScrollX = this.ApplyHorizontalScroll(this.Child, this.ScrollX, this.ScrollbarViewport);
+                this.ScrollY = this.ApplyVerticalScroll(this.Child, this.ScrollY, this.ScrollbarViewport);
 
                 this.ScrollbarBehavior.ExtentWidth = this.Child.DrawRect.W - this.ScrollbarViewport.W;
                 this.ScrollbarBehavior.HorizontalOffset = this.ScrollX;
                 this.ScrollbarBehavior.ExtentHeight = this.Child.DrawRect.H - this.ScrollbarViewport.H;
                 this.ScrollbarBehavior.VerticalOffset = this.ScrollY;
+
+                this.Child.OnArrange(window, new SDL.FPoint() { X = this.Child.DrawRect.X, Y = this.Child.DrawRect.Y });
             }
         }
         public override void FrameworkRender(Window window, SDL.Rect? clipRect = null)
@@ -150,7 +171,7 @@ namespace PhotonUI.Controls.Viewport
 
         #endregion
 
-        #region ScrollBox: Hooks
+        #region ScrollBlock: Hooks
 
         protected override void OnPropertyChanged(PropertyChangedEventArgs e)
         {
@@ -204,6 +225,53 @@ namespace PhotonUI.Controls.Viewport
                 case MouseExitEventArgs mouseExited:
                     mouseExited.Handled = true;
                     break;
+            }
+        }
+
+        #endregion
+
+        #region ScrollBlock: Helpers
+
+        public float ApplyHorizontalScroll(Control child, float scrollX, SDL.FRect viewport)
+        {
+            SDL.FRect scrolled = child.DrawRect;
+
+            float baseX = this.DrawRect.X;
+
+            if (scrolled.W <= viewport.W)
+            {
+                scrolled.X = baseX;
+                child.DrawRect = scrolled;
+                return 0;
+            }
+            else
+            {
+                float maxScrollX = scrolled.W - viewport.W;
+                scrollX = Math.Clamp(scrollX, 0, maxScrollX);
+                scrolled.X = baseX - scrollX;
+                child.DrawRect = scrolled;
+                return scrollX;
+            }
+        }
+        public float ApplyVerticalScroll(Control child, float scrollY, SDL.FRect viewport)
+        {
+            SDL.FRect scrolled = child.DrawRect;
+
+            float baseY = this.DrawRect.Y;
+
+            if (scrolled.H <= viewport.H)
+            {
+                scrolled.Y = baseY;
+                child.DrawRect = scrolled;
+                return 0;
+            }
+            else
+            {
+                float maxScrollY = scrolled.H - viewport.H;
+                scrollY = Math.Clamp(scrollY, 0, maxScrollY);
+                scrolled.Y = baseY - scrollY;
+                child.DrawRect = scrolled;
+                return scrollY;
             }
         }
 

--- a/PhotonUI/Models/Properties/StackProperties.cs
+++ b/PhotonUI/Models/Properties/StackProperties.cs
@@ -7,22 +7,18 @@ namespace PhotonUI.Models.Properties
         Vertical,
         Horizontal
     }
-    public enum StackFillType
-    {
-        None,
-        Equal,
-        First,
-        Last
-    }
 
     public interface IStackProperties : IStyleProperties
     {
         Orientation StackOrientation { get; }
-        StackFillType StackFillType { get; }
+        float Spacing { get; }
     }
 
-    public readonly record struct StackProperties(Orientation StackOrientation, StackFillType StackFillType) : IStackProperties
+    public readonly record struct StackProperties(Orientation StackOrientation, float Spacing) : IStackProperties
     {
-        public static StackProperties Default => new(Orientation.Vertical, StackFillType.None);
+        public static StackProperties Default => new(
+            Orientation.Vertical,
+            0
+        );
     }
 }

--- a/PhotonUI/Photon.cs
+++ b/PhotonUI/Photon.cs
@@ -393,64 +393,88 @@ namespace PhotonUI
 
         public static Size GetMinimumSize(Control control, Size? childSize = null)
         {
-            float coreWidth = childSize?.Width ?? control.MinWidth;
-            float coreHeight = childSize?.Height ?? control.MinHeight;
+            // get the childs size if a child exists
+            float childWidth = childSize?.Width ?? 0;
+            float childHeight = childSize?.Height ?? 0;
 
-            float effectiveWidth = Math.Clamp(coreWidth, control.MinWidth, control.MaxWidth);
-            float effectiveHeight = Math.Clamp(coreHeight, control.MinHeight, control.MaxHeight);
+            // take the larger of the two sizes
+            float coreWidth = childWidth > control.MinWidth ? childWidth : control.MinWidth;
+            float coreHeight = childHeight > control.MinHeight ? childHeight : control.MinHeight;
 
-            float width = effectiveWidth + control.PaddingExtent.Horizontal;
-            float height = effectiveHeight + control.PaddingExtent.Vertical;
+            // inflate the size by the padding extent
+            float effectiveWidth = coreWidth + control.PaddingExtent.Horizontal;
+            float effectiveHeight = coreHeight + control.PaddingExtent.Vertical;
+
+            // camp to control constraints
+            float width = Math.Clamp(effectiveWidth, control.MinWidth, control.MaxWidth);
+            float height = Math.Clamp(effectiveHeight, control.MinHeight, control.MaxHeight);
 
             return new Size { Width = width, Height = height };
         }
 
-        public static float GetStretchedWidth(HorizontalAlignment alignment, float width, float available, float offsetX = 0)
+        public static Size GetStretchedSize(Control parent, Control child, bool allowStretchW = true, bool allowStretchH = true)
         {
-            if (alignment != HorizontalAlignment.Stretch)
-                return width;
+            // get the parents available space
+            SDL.FRect containerRect = parent.DrawRect.Deflate(parent.PaddingExtent);
 
-            float usable = available - offsetX;
-            if (usable >= width)
-                return usable;
+            // set the result to the base intrinsic size
+            Size result = new(child.IntrinsicSize.Width, child.IntrinsicSize.Height);
 
-            return width;
+            // perform width stretch if allowed
+            if (allowStretchW && child.HorizontalAlignment == HorizontalAlignment.Stretch)
+            {
+                // get width of the container minus the child's margins
+                float adjustedWidth = containerRect.W - child.MarginExtent.Horizontal;
+
+                // clamp result to constraints
+                result.Width = Math.Clamp(adjustedWidth, child.MinWidth, child.MaxWidth);
+            }
+
+            // perform height stretch if allowed
+            if (allowStretchH && child.VerticalAlignment == VerticalAlignment.Stretch)
+            {
+                // get height of the container minus the child's margins
+                float adjustedHeight = containerRect.H - child.MarginExtent.Vertical;
+
+                // clamp result to constraints
+                result.Height = Math.Clamp(adjustedHeight, child.MinHeight, child.MaxHeight);
+            }
+
+            return result;
         }
-        public static float GetStretchedHeight(VerticalAlignment alignment, float height, float available, float offsetY = 0)
+        public static SDL.FPoint GetRelativePosition(Control parent, Control child)
         {
-            if (alignment != VerticalAlignment.Stretch)
-                return height;
+            // get the parents available space
+            SDL.FRect containerRect = parent.DrawRect.Deflate(parent.PaddingExtent);
 
-            float usable = available - offsetY;
-            if (usable >= height)
-                return usable;
+            // set the result to parent container rect
+            SDL.FPoint result = new()
+            {
+                X = containerRect.X + child.MarginExtent.Left,
+                Y = containerRect.Y + child.MarginExtent.Top
+            };
 
-            return height;
-        }
-
-        public static float GetHorizontalAlignment(HorizontalAlignment alignment, float intial, float width, float availableWidth)
-        {
-            switch (alignment)
+            switch (child.HorizontalAlignment)
             {
                 case HorizontalAlignment.Center:
-                    return intial + (availableWidth - width) / 2;
+                    result.X = containerRect.X + ((containerRect.W - child.DrawRect.W) / 2) + child.MarginExtent.Left;
+                    break;
                 case HorizontalAlignment.Right:
-                    return intial + (availableWidth - width);
-                default:
-                    return intial;
+                    result.X = containerRect.X + (containerRect.W - child.DrawRect.W) - child.MarginExtent.Right;
+                    break;
             }
-        }
-        public static float GetVerticalAlignment(VerticalAlignment alignment, float intial, float height, float availableHeight)
-        {
-            switch (alignment)
+
+            switch (child.VerticalAlignment)
             {
                 case VerticalAlignment.Center:
-                    return intial + (availableHeight - height) / 2;
+                    result.Y = containerRect.Y + ((containerRect.H - child.DrawRect.H) / 2) + child.MarginExtent.Top;
+                    break;
                 case VerticalAlignment.Bottom:
-                    return intial + (availableHeight - height);
-                default:
-                    return intial;
+                    result.Y = containerRect.Y + (containerRect.H - child.DrawRect.H) - child.MarginExtent.Bottom;
+                    break;
             }
+
+            return result;
         }
 
         public static float GetEdgeScrollHorizontal(float currentOffset, float mouseLocalX, float viewportWidth, float contentWidth, float scrollStep, float scrollMultiplier = 1f, float edgeThreshold = 0)
@@ -480,67 +504,6 @@ namespace PhotonUI
                 return Math.Min(maxOffset, currentOffset + step);
 
             return currentOffset;
-        }
-
-        #endregion
-
-        #region Photon: Control Layout Helpers
-
-        public static float GetMeasuredStackWidth(IReadOnlyList<Control> children)
-        {
-            float total = 0f;
-            foreach (Control child in children)
-                if (child != null) total += child.DrawRect.W + child.MarginExtent.Horizontal;
-            return total;
-        }
-        public static float GetMeasuredStackHeight(IReadOnlyList<Control> children)
-        {
-            float total = 0f;
-            foreach (Control child in children)
-                if (child != null) total += child.DrawRect.H + child.MarginExtent.Vertical;
-            return total;
-        }
-
-        public static float ApplyHorizontalScroll(Control control, float scrollX, SDL.FRect viewport)
-        {
-            SDL.FRect scrolled = control.DrawRect;
-            float baseX = scrolled.X;
-
-            if (scrolled.W <= viewport.W)
-            {
-                scrolled.X = baseX;
-                control.DrawRect = scrolled;
-                return 0;
-            }
-            else
-            {
-                float maxScrollX = scrolled.W - viewport.W;
-                scrollX = Math.Clamp(scrollX, 0, maxScrollX);
-                scrolled.X = baseX - scrollX;
-                control.DrawRect = scrolled;
-                return scrollX;
-            }
-        }
-        public static float ApplyVerticalScroll(Control control, float scrollY, SDL.FRect viewport)
-        {
-            SDL.FRect scrolled = control.DrawRect;
-
-            float baseY = scrolled.Y;
-
-            if (scrolled.H <= viewport.H)
-            {
-                scrolled.Y = baseY;
-                control.DrawRect = scrolled;
-                return 0;
-            }
-            else
-            {
-                float maxScrollY = scrolled.H - viewport.H;
-                scrollY = Math.Clamp(scrollY, 0, maxScrollY);
-                scrolled.Y = baseY - scrollY;
-                control.DrawRect = scrolled;
-                return scrollY;
-            }
         }
 
         #endregion


### PR DESCRIPTION
## Description  
This change resolves layout inconsistencies that caused child controls to be incorrectly positioned and sized within their parent containers. In previous builds, margins were being applied twice (during both the parent’s arrange pass and the child’s alignment step) resulting in visual offsets and misaligned content. Additionally, stacked and scrollable layouts could distort child sizes or allow scrolling beyond valid ranges.

The updated layout logic now applies padding, margin, alignment, and stretching factors exactly once and in the correct order. Stack-based layouts respect each child’s intrinsic size plus defined spacing, while scrollable areas clamp content offsets to valid bounds to keep scrollbar behavior accurate. These refinements create predictable, consistent positioning and ensure nested layouts, alignment modes, and scrolling mechanics all behave as expected.

## Related Issue  
- Fixes #79  
- Fixes #80  

## Motivation and Context  
These bugs caused visual inconsistencies where controls appeared misaligned, stretched incorrectly, or scrolled beyond valid bounds. This update ensures that padding, margin, and alignment are handled exactly once and that stacked and scrollable layouts behave consistently.  

## How Has This Been Tested?  
Verified that the project compiles successfully. No runtime or UI regressions were tested yet.  

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Asset change (adds or updates icons, templates, or other assets)  
- [ ] Documentation change (adds or updates documentation)  
- [ ] Plugin change (adds or updates a plugin)  

## Checklist:  
- [x] I have read the **CONTRIBUTING** document.  
- [x] My change requires a change to the core logic.  
  - [x] I have linked the project issue above.  
- [ ] My change requires a change to the assets.  
  - [ ] I have linked the asset issue above.  
- [ ] My change requires a change to the documentation.  
  - [ ] I have linked the documentation issue above.  
- [ ] My change requires a change to a plugin.  
  - [ ] I have linked the plugin issue above.  