### PR TITLE
Remove Stored Window from Controls

### DIFF
--- a/PhotonUI/Behaviors/ScrollBehavior.cs
+++ b/PhotonUI/Behaviors/ScrollBehavior.cs
@@ -172,11 +172,13 @@ namespace PhotonUI.Behaviors
             this.IsHorizontalCaretDown = false;
             this.WasHorizontalTrackClicked = false;
 
+            Window window = Photon.GetWindow(this.Control);
+
             if (this.VerticalCaretRect.HasValue && Photon.HitTest(this.VerticalCaretRect.Value, px, py))
             {
                 this.IsVerticalCaretDown = true;
 
-                this.Control.Window?.CapturePointer(this.Control);
+                window.CapturePointer(this.Control);
 
                 return;
             }
@@ -188,7 +190,7 @@ namespace PhotonUI.Behaviors
             }
             if (this.HorizontalCaretRect.HasValue && Photon.HitTest(this.HorizontalCaretRect.Value, px, py))
             {
-                this.Control.Window?.CapturePointer(this.Control);
+                window.CapturePointer(this.Control);
 
                 this.IsHorizontalCaretDown = true;
 
@@ -292,7 +294,8 @@ namespace PhotonUI.Behaviors
                 }
             }
 
-            this.Control?.Window?.ReleasePointer();
+            if (this.Control != null)
+                Photon.GetWindow(this.Control).ReleasePointer();
 
             this.IsVerticalCaretDown = false;
             this.WasVerticalTrackClicked = false;

--- a/PhotonUI/Controls/Canvas.cs
+++ b/PhotonUI/Controls/Canvas.cs
@@ -31,14 +31,13 @@ namespace PhotonUI.Controls
 
             if (this.IsInitialized)
             {
-                if (this.Window == null)
-                    throw new InvalidOperationException($"Control '{this.Name}' is not associated with a RootWindow.");
+                Window window = Photon.GetWindow(this);
 
-                control.FrameworkInitialize(this.Window);
+                control.OnInitialize(window);
 
                 ChildChangedEventArgs args = new(this, control, ChildChangeAction.Added);
 
-                this.FrameworkEventBubble(this.Window, args);
+                this.FrameworkEventBubble(window, args);
             }
 
             this.ChildAddedAction?.Invoke(control);
@@ -54,12 +53,11 @@ namespace PhotonUI.Controls
 
             if (this.IsInitialized)
             {
-                if (this.Window == null)
-                    throw new InvalidOperationException($"Control '{this.Name}' is not associated with a RootWindow.");
+                Window window = Photon.GetWindow(this);
 
                 ChildChangedEventArgs args = new(this, control, ChildChangeAction.Removed);
 
-                this.FrameworkEventBubble(this.Window, args);
+                this.FrameworkEventBubble(window, args);
             }
 
             this.ChildRemovedAction?.Invoke(control);
@@ -180,6 +178,19 @@ namespace PhotonUI.Controls
                     Photon.ApplyControlClipRect(window, clipRect);
                 }
             }
+        }
+
+        #endregion
+
+        #region Control: Hooks
+
+        public override void OnInitialize(Window window)
+        {
+            if (!this.IsInitialized)
+                this.FrameworkInitialize(window);
+
+            foreach (Control child in this.Children)
+                child?.OnInitialize(window);
         }
 
         #endregion

--- a/PhotonUI/Controls/Content/ImageBlock.cs
+++ b/PhotonUI/Controls/Content/ImageBlock.cs
@@ -63,13 +63,6 @@ namespace PhotonUI.Controls.Content
             base.RequestRender(invalidate);
         }
 
-        public override void FrameworkInitialize(Window window)
-        {
-            base.FrameworkInitialize(window);
-
-            if (this.LoadSourceTexture(window))
-                this.RebuildTexture(window);
-        }
         public override void FrameworkRender(Window window, SDL.Rect? clipRect)
         {
             if (this.IsVisible)
@@ -120,9 +113,6 @@ namespace PhotonUI.Controls.Content
             if (!this.IsInitialized)
                 return;
 
-            if (this.Window == null)
-                throw new InvalidOperationException("Image property change: RootWindow == null.");
-
             base.OnPropertyChanged(e);
 
             bool invalidateMeasure = false;
@@ -149,6 +139,14 @@ namespace PhotonUI.Controls.Content
 
             if (invalidateRender)
                 this.RequestRenderWithFlags(imageDirty: invalidateImage);
+        }
+
+        public override void OnInitialize(Window window)
+        {
+            base.OnInitialize(window);
+
+            if (this.LoadSourceTexture(window))
+                this.RebuildTexture(window);
         }
 
         public override void Dispose()

--- a/PhotonUI/Controls/Content/SpriteBlock.cs
+++ b/PhotonUI/Controls/Content/SpriteBlock.cs
@@ -114,9 +114,6 @@ namespace PhotonUI.Controls.Content
             if (!this.IsInitialized)
                 return;
 
-            if (this.Window == null)
-                throw new InvalidOperationException("Sprite property change: RootWindow == null.");
-
             base.OnPropertyChanged(e);
 
             bool invalidateMeasure = false;
@@ -148,7 +145,7 @@ namespace PhotonUI.Controls.Content
                     invalidateMeasure = true;
                     invalidateLayout = true;
                     invalidateRender = true;
-                    if (this.TryLoadPlayer(this.Window)) this.Player?.Play();
+                    if (this.TryLoadPlayer(Photon.GetWindow(this))) this.Player?.Play();
                     break;
 
                 case nameof(this.FlipX):

--- a/PhotonUI/Controls/Content/TextBlock.cs
+++ b/PhotonUI/Controls/Content/TextBlock.cs
@@ -153,12 +153,7 @@ namespace PhotonUI.Controls.Content
                 Photon.InvalidateRenderChain(this);
         }
 
-        public override void FrameworkInitialize(Window window)
-        {
-            base.FrameworkInitialize(window);
 
-            this.RebuildFont();
-        }
         public override void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
             this.DrawRect.X = anchor.X + this.X;
@@ -219,9 +214,6 @@ namespace PhotonUI.Controls.Content
         {
             if (!this.IsInitialized)
                 return;
-
-            if (this.Window == null)
-                throw new InvalidOperationException($"Control '{this.Name}' is not associated to a RootWindow.");
 
             base.OnPropertyChanged(e);
 
@@ -295,6 +287,12 @@ namespace PhotonUI.Controls.Content
                 this.RebuildFont();
         }
 
+        public override void OnInitialize(Window window)
+        {
+            this.RebuildFont();
+
+            base.OnInitialize(window);
+        }
         public override void OnEvent(Window window, FrameworkEventArgs e)
         {
             if (e.Handled == true || e.Preview == true) return;

--- a/PhotonUI/Controls/Control.cs
+++ b/PhotonUI/Controls/Control.cs
@@ -26,7 +26,6 @@ namespace PhotonUI.Controls
         protected readonly IServiceProvider ServiceProvider = serviceProvider;
         protected readonly IBindingService BindingService = bindingService;
 
-        public Window? Window;
         public Size IntrinsicSize;
         public SDL.FRect DrawRect;
 
@@ -320,23 +319,15 @@ namespace PhotonUI.Controls
 
             if (!this.IsInitialized)
             {
-                this.Window = window;
                 this.IsInitialized = true;
 
                 this.OnInitialize(window);
 
                 if (this.IsFocused)
                     window.SetFocus(this);
+
+                this.InitializedAction?.Invoke(this);
             }
-
-            this.TunnelControls(control =>
-            {
-                if (control != this)
-                    control.FrameworkInitialize(window);
-                return true;
-            });
-
-            this.InitializedAction?.Invoke(this);
         }
         public virtual void FrameworkTick(Window window) { }
         public virtual void FrameworkIntrinsic(Window window, Size content)
@@ -384,9 +375,6 @@ namespace PhotonUI.Controls
             if (!this.IsInitialized)
                 return;
 
-            if (this.Window == null)
-                throw new InvalidOperationException($"Control '{this.Name}' is not associated to a RootWindow.");
-
             base.OnPropertyChanged(e);
 
             bool invalidateMeasure = false;
@@ -429,10 +417,14 @@ namespace PhotonUI.Controls
             if (invalidateRender)
                 this.RequestRender(true);
 
-            this.FrameworkEventBubble(this.Window, new ChildPropertyChangedEventArgs(this, e));
+            this.FrameworkEventBubble(Photon.GetWindow(this), new ChildPropertyChangedEventArgs(this, e));
         }
 
-        public virtual void OnInitialize(Window window) { }
+        public virtual void OnInitialize(Window window)
+        {
+            if (!this.IsInitialized)
+                this.FrameworkInitialize(window);
+        }
         public virtual void OnTick(Window window)
         {
             this.FrameworkTick(window);

--- a/PhotonUI/Controls/Decorators/Border.cs
+++ b/PhotonUI/Controls/Decorators/Border.cs
@@ -70,9 +70,6 @@ namespace PhotonUI.Controls.Decorators
             if (!this.IsInitialized)
                 return;
 
-            if (this.Window == null)
-                throw new InvalidOperationException($"Control '{this.Name}' is not associated to a RootWindow.");
-
             base.OnPropertyChanged(e);
 
             bool invalidateMeasure = false;

--- a/PhotonUI/Controls/Layout/StackBlock.cs
+++ b/PhotonUI/Controls/Layout/StackBlock.cs
@@ -147,9 +147,6 @@ namespace PhotonUI.Controls.Layout
             if (!this.IsInitialized)
                 return;
 
-            if (this.Window == null)
-                throw new InvalidOperationException($"Control '{this.Name}' is not associated to a RootWindow.");
-
             base.OnPropertyChanged(e);
 
             bool invalidateMeasure = false;

--- a/PhotonUI/Controls/Presenter.cs
+++ b/PhotonUI/Controls/Presenter.cs
@@ -23,11 +23,8 @@ namespace PhotonUI.Controls
             {
                 oldValue.Parent = null;
 
-                if (IsInitialized && Window != null)
-                {
-                    FrameworkEventBubble(Window,
-                        new ChildChangedEventArgs(this, oldValue, ChildChangeAction.Removed));
-                }
+                if (this.IsInitialized)
+                    FrameworkEventBubble(Photon.GetWindow(this), new ChildChangedEventArgs(this, oldValue, ChildChangeAction.Removed));
             }
 
             if (newValue != null)
@@ -37,18 +34,15 @@ namespace PhotonUI.Controls
 
                 newValue.Parent = this;
 
-                if (IsInitialized)
+                if (this.IsInitialized)
                 {
-                    if (Window == null)
-                        throw new InvalidOperationException($"Control '{newValue.Name}' is not associated with a RootWindow.");
+                    Window window = Photon.GetWindow(newValue);
 
-                    FrameworkEventBubble(Window, new ChildChangedEventArgs(this, newValue, ChildChangeAction.Added));
+                    FrameworkEventBubble(window, new ChildChangedEventArgs(this, newValue, ChildChangeAction.Added));
 
-                    newValue.FrameworkInitialize(Window);
+                    newValue.OnInitialize(window);
                 }
             }
-
-            RequestArrange();
         }
 
         #region Presenter: Framework
@@ -142,6 +136,18 @@ namespace PhotonUI.Controls
                     Photon.ApplyControlClipRect(window, clipRect);
                 }
             }
+        }
+
+        #endregion
+
+        #region Control: Hooks
+
+        public override void OnInitialize(Window window)
+        {
+            if (!this.IsInitialized)
+                this.FrameworkInitialize(window);
+
+            this.Child?.OnInitialize(window);
         }
 
         #endregion

--- a/PhotonUI/Controls/Viewport/ScrollBlock.cs
+++ b/PhotonUI/Controls/Viewport/ScrollBlock.cs
@@ -178,9 +178,6 @@ namespace PhotonUI.Controls.Viewport
             if (!this.IsInitialized)
                 return;
 
-            if (this.Window == null)
-                throw new InvalidOperationException($"Control '{this.Name}' is not associated to a RootWindow.");
-
             base.OnPropertyChanged(e);
 
             bool invalidateLayout = false;

--- a/PhotonUI/Controls/Window.cs
+++ b/PhotonUI/Controls/Window.cs
@@ -74,7 +74,7 @@ namespace PhotonUI.Controls
             this.DefaultSize = size;
             this.DefaultFlags = flags;
 
-            this.FrameworkInitialize(this);
+            this.OnInitialize(this);
         }
         public virtual void Tick()
         {
@@ -298,10 +298,7 @@ namespace PhotonUI.Controls
 
             this.Child.TunnelControls((c) =>
             {
-                if (c.Window == null)
-                    throw new InvalidOperationException($"The control {c.Name} of type {c.GetType().Name} has no window");
-
-                c.OnTick(c.Window);
+                c.OnTick(this);
                 c.TickAction?.Invoke(c);
 
                 return true;
@@ -401,10 +398,7 @@ namespace PhotonUI.Controls
 
             this.Child.TunnelControls((c) =>
             {
-                if (c.Window == null)
-                    throw new InvalidOperationException($"The control {c.Name} of type {c.GetType().Name} has no window");
-
-                c.OnLateTick(c.Window);
+                c.OnLateTick(this);
                 c.LateTickAction?.Invoke(c);
 
                 return true;
@@ -444,10 +438,7 @@ namespace PhotonUI.Controls
 
             this.Child.TunnelControls((c) =>
             {
-                if (c.Window == null)
-                    throw new InvalidOperationException($"The control {c.Name} of type {c.GetType().Name} has no window");
-
-                c.OnPostTick(c.Window);
+                c.OnPostTick(this);
                 c.PostTickAction?.Invoke(c);
 
                 return true;
@@ -461,12 +452,9 @@ namespace PhotonUI.Controls
             {
                 if (c.IsBoundryDirty)
                 {
-                    if (c.Window == null)
-                        throw new InvalidOperationException($"The control {c.Name} of type {c.GetType().Name} has no window");
-
                     SDL.FRect renderRect = FRect.Deflate(c.DrawRect, c.Margin);
 
-                    Photon.ClearRectangle(c.Window, renderRect, c.Window.BackTexture, default);
+                    Photon.ClearRectangle(this, renderRect, this.BackTexture, default);
 
                     c.IsBoundryDirty = false;
                     c.IsRenderDirty = true;
@@ -494,8 +482,6 @@ namespace PhotonUI.Controls
 
             for (int i = currentPath.Count - 1; i >= 0; i--)
             {
-                Control control = currentPath[i];
-
                 if (!focusSet)
                 {
                     focusSet = true;
@@ -528,7 +514,11 @@ namespace PhotonUI.Controls
             }
         }
 
-        public override void FrameworkInitialize(Window window)
+        #endregion
+
+        #region Control: Hooks
+
+        public override void OnInitialize(Window window)
         {
             if (window.IsInitialized == true) return;
 
@@ -563,22 +553,11 @@ namespace PhotonUI.Controls
             }
 
             window.Name = window.Name;
-            window.Window = window;
             window.HorizontalAlignment = Models.Properties.HorizontalAlignment.Stretch;
             window.VerticalAlignment = Models.Properties.VerticalAlignment.Stretch;
             window.IsInitialized = true;
 
-            window.Child?.FrameworkInitialize(window);
-
-            this.SuppressRendering = true;
-
-            window.Tick();
-
-            this.SuppressRendering = false;
-
-            window.RequestMeasure();
-            window.RequestArrange();
-            window.RequestRender();
+            window.Child?.OnInitialize(window);
         }
 
         #endregion

--- a/PhotonUI/Photon.cs
+++ b/PhotonUI/Photon.cs
@@ -14,13 +14,6 @@ namespace PhotonUI
 {
     public static class Photon
     {
-        public static void EnsureRootWindow(Control control)
-        {
-            ArgumentNullException.ThrowIfNull(control);
-
-            if (control.Window is null)
-                throw new InvalidOperationException($"Control '{control.Name}' has no RootWindow.");
-        }
         public static Window GetWindow(Control control)
         {
             Control? current = control;
@@ -51,13 +44,10 @@ namespace PhotonUI
                 return true;
             });
 
-            boundary ??= control.Window;
+            boundary ??= Photon.GetWindow(control);
 
-            if (boundary?.Window != null)
-            {
-                boundary.RequestRender(false);
-                boundary.IsBoundryDirty = true;
-            }
+            boundary.RequestRender(false);
+            boundary.IsBoundryDirty = true;
         }
 
         public static SDL.FRect ScaleRect(SDL.FRect rect, Vector2 scale, SDL.FPoint anchor)
@@ -829,7 +819,7 @@ namespace PhotonUI
 
         public static void DrawControlBackground<T>(T control) where T : Control, IControlProperties
         {
-            EnsureRootWindow(control);
+            Window window = Photon.GetWindow(control);
 
             SDL.Color adjusted = new()
             {
@@ -841,11 +831,11 @@ namespace PhotonUI
 
             SDL.FRect drawSurface = control.DrawRect;
 
-            DrawRectangle(control.Window!, drawSurface, adjusted, control.Window?.BackTexture ?? default);
+            DrawRectangle(window, drawSurface, adjusted, window.BackTexture);
         }
         public static void DrawControlBackground<T>(T control, ControlProperties props) where T : Control, IControlProperties
         {
-            EnsureRootWindow(control);
+            Window window = Photon.GetWindow(control);
 
             SDL.Color adjusted = new()
             {
@@ -857,34 +847,34 @@ namespace PhotonUI
 
             SDL.FRect drawSurface = control.DrawRect;
 
-            DrawRectangle(control.Window!, drawSurface, adjusted, control.Window?.BackTexture ?? default);
+            DrawRectangle(window, drawSurface, adjusted, window.BackTexture);
         }
 
         public static void DrawControlBorder<T>(T control) where T : Control, IBorderProperties, IControlProperties
         {
-            EnsureRootWindow(control);
+            Window window = Photon.GetWindow(control);
 
             BorderColors adjusted = control.BorderColors.WithOpacity(control.Opacity);
 
             SDL.FRect drawSurface = control.DrawRect;
 
-            DrawBorder(control.Window!, drawSurface, control.BorderThickness, adjusted, control.Window!.BackTexture);
+            DrawBorder(window, drawSurface, control.BorderThickness, adjusted, window.BackTexture);
         }
         public static void DrawControlBorder<T>(T control, BorderProperties props, ControlProperties controlProps)
             where T : Control, IBorderProperties
         {
-            EnsureRootWindow(control);
+            Window window = Photon.GetWindow(control);
 
             BorderColors adjusted = props.BorderColors.WithOpacity(controlProps.Opacity);
 
             SDL.FRect drawSurface = control.DrawRect;
 
-            DrawBorder(control.Window!, drawSurface, props.BorderThickness, adjusted, control.Window!.BackTexture);
+            DrawBorder(window, drawSurface, props.BorderThickness, adjusted, window.BackTexture);
         }
 
         public static void DrawControlTexture<T>(T control, IntPtr texture, SDL.FRect destination, SDL.Rect? clipRect = null) where T : Control, IControlProperties
         {
-            EnsureRootWindow(control);
+            Window window = Photon.GetWindow(control);
 
             SDL.GetTextureAlphaMod(texture, out byte originalAlpha);
 
@@ -892,13 +882,13 @@ namespace PhotonUI
 
             SDL.SetTextureAlphaMod(texture, newAlpha);
 
-            DrawTexture(control.Window!, texture, destination, control.Window!.BackTexture, null, clipRect);
+            DrawTexture(window, texture, destination, window.BackTexture, null, clipRect);
 
             SDL.SetTextureAlphaMod(texture, originalAlpha);
         }
         public static void DrawControlTexture<T>(T control, IntPtr texture, SDL.FRect destination, SDL.FRect? sourceRect = null, SDL.Rect? clipRect = null) where T : Control, IControlProperties
         {
-            EnsureRootWindow(control);
+            Window window = Photon.GetWindow(control);
 
             SDL.GetTextureAlphaMod(texture, out byte originalAlpha);
 
@@ -906,14 +896,14 @@ namespace PhotonUI
 
             SDL.SetTextureAlphaMod(texture, newAlpha);
 
-            DrawTexture(control.Window!, texture, destination, control.Window!.BackTexture, sourceRect, clipRect);
+            DrawTexture(window, texture, destination, window.BackTexture, sourceRect, clipRect);
 
             SDL.SetTextureAlphaMod(texture, originalAlpha);
         }
 
         public static void DrawControlTextureRotated<T>(T control, IntPtr texture, SDL.FRect destination, double angle, SDL.FPoint center, SDL.FlipMode flip, SDL.Rect? clipRect = null) where T : Control, IControlProperties
         {
-            EnsureRootWindow(control);
+            Window window = Photon.GetWindow(control);
 
             SDL.GetTextureAlphaMod(texture, out byte originalAlpha);
 
@@ -921,13 +911,13 @@ namespace PhotonUI
 
             SDL.SetTextureAlphaMod(texture, newAlpha);
 
-            DrawTextureRotated(control.Window!, texture, null, destination, angle, center, flip, control.Window!.BackTexture, clipRect);
+            DrawTextureRotated(window, texture, null, destination, angle, center, flip, window.BackTexture, clipRect);
 
             SDL.SetTextureAlphaMod(texture, originalAlpha);
         }
         public static void DrawControlTextureRotated<T>(T control, IntPtr texture, SDL.FRect destination, SDL.FRect? sourceRect, double angle, SDL.FPoint center, SDL.FlipMode flip, SDL.Rect? clipRect = null) where T : Control, IControlProperties
         {
-            EnsureRootWindow(control);
+            Window window = Photon.GetWindow(control);
 
             SDL.GetTextureAlphaMod(texture, out byte originalAlpha);
 
@@ -935,7 +925,7 @@ namespace PhotonUI
 
             SDL.SetTextureAlphaMod(texture, newAlpha);
 
-            DrawTextureRotated(control.Window!, texture, sourceRect, destination, angle, center, flip, control.Window!.BackTexture, clipRect);
+            DrawTextureRotated(window, texture, sourceRect, destination, angle, center, flip, window.BackTexture, clipRect);
 
             SDL.SetTextureAlphaMod(texture, originalAlpha);
         }


### PR DESCRIPTION
This change removes the stored `Window` reference from `Control` and all derived controls, replacing it with dynamic window resolution via `Photon.GetWindow(Control)`. It also ensures that `OnInitialize(Window)` is properly used as the initialization entry point, aligning with the existing `On*` lifecycle methods, and propagates initialization through container controls such as `Canvas`, `Presenter`, and `Window`.

## Related Issue
- Resolves #86

## Motivation and Context
Controls previously stored a reference to their root `Window`, which added redundancy and required defensive checks for null. By decoupling controls from `Window`, the system relies on the control hierarchy for window resolution, simplifying lifecycle management, reducing redundant state, and standardizing initialization.

## How Has This Been Tested?
- Verified that all controls (including `TextBlock`, `ImageBlock`, `SpriteBlock`, `Border`, `StackBlock`, `ScrollBlock`, `Presenter`) initialize correctly via `OnInitialize`.
- Verified compilation

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.