### PR TITLE
Adding optional diagnostics framework

### DIFF
--- a/PhotonUI.Desktop/Diagnostics/DiagnosticXMLSink.cs
+++ b/PhotonUI.Desktop/Diagnostics/DiagnosticXMLSink.cs
@@ -1,0 +1,380 @@
+﻿using PhotonUI.Controls;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
+using PhotonUI.Models;
+using SDL3;
+using Serilog;
+using System.Reflection;
+using System.Text;
+
+namespace PhotonUI.Desktop.Diagnostics
+{
+    public class DiagnosticXMLSink : IPhotonDiagnostics
+    {
+        protected ILogger? Logger = null;
+
+        protected readonly Stack<bool> WriteStack = new();
+
+        protected bool ShouldIncludeParameters = false;
+        protected bool ShouldIncludeParameterNames = false;
+        protected bool ShouldIncludeTimestamps = false;
+
+        protected bool Running = false;
+        protected string Path = "photonui.debug.xml";
+        protected string Header = "";
+        protected string Footer = "";
+
+        private readonly Stack<DiagnosticEventArgs> pendingGroupStarts = [];
+        private readonly Stack<bool> groupWriteStack = new();
+
+        public Func<DiagnosticEventArgs, bool>? GroupPredicate { get; set; }
+        public List<Func<DiagnosticEventArgs, bool>> ScopeFilters { get; } = [];
+
+        public DiagnosticXMLSink()
+        {
+            this.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.File(this.Path, shared: true, outputTemplate: "{Message:l}{NewLine}")
+                .CreateLogger();
+
+            AppDomain.CurrentDomain.ProcessExit += (s, e) =>
+            {
+                this.Stop();
+            };
+        }
+
+        #region DiagnosticXMLSink: Fluent API
+
+        public DiagnosticXMLSink ResetOutput()
+        {
+            (this.Logger as IDisposable)?.Dispose();
+
+            if (File.Exists(this.Path))
+                File.Delete(this.Path);
+
+            this.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.File(this.Path, shared: true, outputTemplate: "{Message:l}{NewLine}")
+                .CreateLogger();
+
+            return this;
+        }
+        public DiagnosticXMLSink SetOutput(string path)
+        {
+            (this.Logger as IDisposable)?.Dispose();
+
+            this.Path = path;
+
+            this.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.File(this.Path, shared: true, outputTemplate: "{Message:l}{NewLine}")
+                .CreateLogger();
+            return this;
+        }
+
+        public DiagnosticXMLSink SetHeader(string header)
+        {
+            this.Header = header;
+            return this;
+        }
+        public DiagnosticXMLSink SetFooter(string footer)
+        {
+            this.Footer = footer;
+            return this;
+        }
+
+        public DiagnosticXMLSink AddScopeFilter(Func<DiagnosticEventArgs, bool> filter)
+        {
+            this.ScopeFilters.Add(filter);
+            return this;
+        }
+        public DiagnosticXMLSink SetGrouping(Func<DiagnosticEventArgs, bool> predicate)
+        {
+            this.GroupPredicate = predicate;
+            return this;
+        }
+
+        public DiagnosticXMLSink IncludeParameters(bool showArgs = true, bool showArgNames = true)
+        {
+            this.ShouldIncludeParameters = showArgs;
+            this.ShouldIncludeParameterNames = showArgNames;
+            return this;
+        }
+        public DiagnosticXMLSink IncludeTimestamps(bool show = true)
+        {
+            this.ShouldIncludeTimestamps = show;
+            return this;
+        }
+
+        #endregion
+
+        public void Start()
+        {
+            if (this.Running) return;
+
+            this.Running = true;
+            this.Logger?.Information(this.Header);
+        }
+        public void Stop()
+        {
+            if (!this.Running) return;
+
+            this.Running = false;
+            this.Logger?.Information(this.Footer);
+
+            (this.Logger as IDisposable)?.Dispose();
+        }
+
+        public void OnEvent(DiagnosticEventArgs e)
+        {
+            if (!this.Running) return;
+
+            bool isStart = e.Phase == DiagnosticPhase.Start;
+            bool isEnd = e.Phase == DiagnosticPhase.End;
+
+            bool hasScopeFilters = this.ScopeFilters.Count > 0;
+            bool writeIsOpen = this.WriteStack.Count > 0 && this.WriteStack.Peek();
+
+            bool matchGroupPredicate = this.GroupPredicate != null && this.GroupPredicate(e);
+            bool matchScopePredicate = this.ScopeFilters.Any(f => f(e));
+
+            bool shouldWrite = !hasScopeFilters || writeIsOpen || matchScopePredicate;
+
+            if (matchGroupPredicate)
+            {
+                if (isStart)
+                {
+                    this.pendingGroupStarts.Push(e);
+                    this.groupWriteStack.Push(false);
+                }
+                else if (isEnd && this.groupWriteStack.Count > 0)
+                {
+                    bool wasWritten = this.groupWriteStack.Pop();
+                    DiagnosticEventArgs startEvent = this.pendingGroupStarts.Pop();
+
+                    if (wasWritten)
+                    {
+                        this.WriteEventXml(e);
+                    }
+                }
+
+                return;
+            }
+
+            if (this.pendingGroupStarts.Count > 0 && matchScopePredicate)
+            {
+                DiagnosticEventArgs[] pending = [.. this.pendingGroupStarts];
+                var writeFlags = this.groupWriteStack.ToArray();
+
+                this.pendingGroupStarts.Clear();
+                this.groupWriteStack.Clear();
+
+                for (int i = pending.Length - 1; i >= 0; i--)
+                {
+                    DiagnosticEventArgs evt = pending[i];
+                    bool alreadyWritten = writeFlags[i];
+
+                    if (!alreadyWritten)
+                    {
+                        this.WriteEventXml(evt);
+
+                        alreadyWritten = true;
+                    }
+
+                    this.pendingGroupStarts.Push(evt);
+                    this.groupWriteStack.Push(alreadyWritten);
+                }
+            }
+
+            if (isStart && matchScopePredicate)
+                this.WriteStack.Push(true);
+
+            if (shouldWrite)
+                this.WriteEventXml(e);
+
+            if (isEnd && matchScopePredicate)
+                if (this.WriteStack.Count > 0)
+                    this.WriteStack.Pop();
+        }
+
+        #region DiagnosticXMLSink: XML Writers
+
+        protected void WriteEventXml(DiagnosticEventArgs e)
+        {
+            string attr = this.FormatAttributes(e);
+
+            switch (e)
+            {
+                case PlatformEventEventArgs @event:
+                    this.WritePlatformXml(@event, attr);
+                    break;
+
+                case PhotonMethodEventArgs method:
+                    this.WritePhotonXml(method, attr, this.FormatParameters(e.MethodInfo, method.Parameters));
+                    break;
+
+                case ControlMethodEventArgs method:
+                    this.WriteControlMethodXml(method, attr, this.FormatParameters(e.MethodInfo, method.Parameters));
+                    break;
+
+                case ControlEventArgs control:
+                    this.WriteControlXml(control, attr);
+                    break;
+            }
+        }
+        protected void WritePlatformXml(PlatformEventEventArgs platform, string attr)
+        {
+            SDL.EventType eventType = (SDL.EventType)platform.Event.NativeEvent.Type;
+
+            // Build extra attributes
+            string extra = $"Preview=\"{platform.Event.Preview}\" Handled=\"{platform.Event.Handled}\"";
+
+            switch (platform.Phase)
+            {
+                case DiagnosticPhase.Atomic:
+                case DiagnosticPhase.Start:
+                    this.Logger?.Information(
+                        "<{0} {1}{2} {3}",
+                        eventType,
+                        extra,
+                        string.IsNullOrWhiteSpace(attr) ? "" : " " + attr.Trim(),
+                        platform.Phase == DiagnosticPhase.Atomic ? "/>" : ">");
+                    break;
+
+                case DiagnosticPhase.End:
+                    this.Logger?.Information("</{0}>", eventType);
+                    break;
+            }
+        }
+
+        protected void WritePhotonXml(PhotonMethodEventArgs method, string attr, string args)
+        {
+            switch (method.Phase)
+            {
+                case DiagnosticPhase.Atomic:
+                case DiagnosticPhase.Start:
+                    string closing = method.Phase == DiagnosticPhase.Atomic ? "/>" : ">";
+                    if (string.IsNullOrEmpty(args))
+                        this.Logger?.Information("<{0} {1} {2}", method.MethodInfo?.Name, attr, closing);
+                    else
+                        this.Logger?.Information("<{0} Params=\"{1}\" {2} {3}", method.MethodInfo?.Name, args, attr, closing);
+                    break;
+
+                case DiagnosticPhase.End:
+                    this.Logger?.Information("</{0}>", method.MethodInfo?.Name);
+                    break;
+            }
+        }
+        protected void WriteControlMethodXml(ControlEventArgs method, string attr, string args)
+        {
+            string methodName = method.MethodInfo != null
+                ? $"{method.MethodInfo.DeclaringType?.Name}.{method.MethodInfo.Name}"
+                : method.MethodInfo?.Name ?? "UnknownMethod";
+
+            switch (method.Phase)
+            {
+                case DiagnosticPhase.Atomic:
+                case DiagnosticPhase.Start:
+                    string closing = method.Phase == DiagnosticPhase.Atomic ? "/>" : ">";
+                    if (string.IsNullOrEmpty(args))
+                        this.Logger?.Information(
+                            "<{0} Control=\"{1}\" ControlType=\"{2}\" {3} {4}",
+                            methodName,
+                            method.Control.Name,
+                            method.Control.GetType().Name,
+                            attr,
+                            closing);
+                    else
+                        this.Logger?.Information(
+                            "<{0} Params=\"{1}\" Control=\"{2}\" ControlType=\"{3}\" {4} {5}",
+                            methodName,
+                            args,
+                            method.Control.Name,
+                            method.Control.GetType().Name,
+                            attr,
+                            closing);
+                    break;
+
+                case DiagnosticPhase.End:
+                    this.Logger?.Information("</{0}>", methodName);
+                    break;
+            }
+        }
+        protected void WriteControlXml(ControlEventArgs method, string attr)
+        {
+            switch (method.Phase)
+            {
+                case DiagnosticPhase.Atomic:
+                case DiagnosticPhase.Start:
+                    this.Logger?.Information(
+                        "<{0} Control=\"{1}\" ControlType=\"{2}\" {3} {4}",
+                        method.GetType().Name,
+                        method.Control.Name,
+                        method.Control.GetType().Name,
+                        attr,
+                        method.Phase == DiagnosticPhase.Atomic ? "/>" : ">");
+                    break;
+
+                case DiagnosticPhase.End:
+                    this.Logger?.Information("</{0}>", method.GetType().Name);
+                    break;
+            }
+        }
+
+        #endregion
+
+        #region DiagnosticXMLSink: Helpers
+
+        protected string FormatAttributes(DiagnosticEventArgs e)
+        {
+            StringBuilder attributes = new();
+
+            if (this.ShouldIncludeTimestamps)
+            {
+                if (SDL3.SDL.GetCurrentTime(out long tick))
+                    attributes.Append($"Tick=\"{tick}\" ");
+            }
+
+            return attributes.ToString();
+        }
+        protected string FormatParameters(MethodInfo? method, List<object?> values)
+        {
+            if (method == null)
+                return string.Empty;
+
+            if (!this.ShouldIncludeParameters)
+                return string.Empty;
+
+            ParameterInfo[] parameters = method.GetParameters();
+            List<string> parts = [];
+
+            for (int i = 0; i < parameters.Length && i < values.Count; i++)
+            {
+                ParameterInfo p = parameters[i];
+                var value = values[i];
+
+                if (p.ParameterType == typeof(Window) || typeof(Delegate).IsAssignableFrom(p.ParameterType))
+                    continue;
+
+                string formatted = value switch
+                {
+                    Size s => $"({s.Width}x{s.Height})",
+                    SDL3.SDL.FPoint pnt => $"({pnt.X},{pnt.Y})",
+                    SDL3.SDL.Rect r => $"({r.X},{r.Y},{r.W},{r.H})",
+                    _ => value?.ToString() ?? "null"
+                };
+
+                if (this.ShouldIncludeParameterNames)
+                    parts.Add($"{p.Name}={formatted}");
+                else
+                    parts.Add(formatted);
+            }
+
+            return string.Join(", ", parts);
+        }
+
+        #endregion
+    }
+}

--- a/PhotonUI.Desktop/PhotonUI.Desktop.csproj
+++ b/PhotonUI.Desktop/PhotonUI.Desktop.csproj
@@ -16,6 +16,7 @@
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<FileVersion>1.0.0.0</FileVersion>
 		<InformationalVersion>1.0.0</InformationalVersion>
+		<Configurations>Debug;Release;Diagnostics;Diagnose</Configurations>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -29,11 +30,24 @@
 
 	<ItemGroup>
 		<!--Dependency Injection-->
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\PhotonUI\PhotonUI.csproj" />
+		<ProjectReference Include="..\PhotonUI\PhotonUI.csproj" />
 	</ItemGroup>
+
+	<!-- Debug build: normal debugging, no diagnostics -->
+	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+		<DefineConstants>DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<!-- Diagnose build: debugging + diagnostics -->
+	<PropertyGroup Condition="'$(Configuration)' == 'Diagnose'">
+		<DefineConstants>DEBUG;PHOTON_DIAGNOSTICS</DefineConstants>
+	</PropertyGroup>
 
 </Project>

--- a/PhotonUI.Desktop/Program.cs
+++ b/PhotonUI.Desktop/Program.cs
@@ -3,8 +3,10 @@ using PhotonUI.Components;
 using PhotonUI.Controls;
 using PhotonUI.Controls.Decorators;
 using PhotonUI.Desktop;
+using PhotonUI.Desktop.Diagnostics;
 using PhotonUI.Desktop.ViewModels;
 using PhotonUI.Desktop.Views;
+using PhotonUI.Diagnostics;
 using PhotonUI.Interfaces.Services;
 using PhotonUI.Models;
 using PhotonUI.Services;
@@ -26,6 +28,8 @@ partial class Program
         Vacuum.Excite(
             services =>
             {
+                services.AddSingleton<IPhotonDiagnostics, DiagnosticXMLSink>();
+
                 services.AddSingleton<IFontService, FontService>();
                 services.AddSingleton<ITextureService, TextureService>();
                 services.AddSingleton<IBindingService, BindingService>();
@@ -39,14 +43,14 @@ partial class Program
 
                 services.AddTransient<MainView>();
                 services.AddTransient<MainViewModel>();
-
                 services.AddTransient<Window>();
             },
             provider =>
             {
+                PhotonDiagnostics.Sink = provider.GetService<IPhotonDiagnostics>();
+
                 view = provider.GetRequiredService<MainView>();
                 viewModel = provider.GetRequiredService<MainViewModel>();
-
                 window = provider.GetRequiredService<Window>();
 
                 if (!SDL.Init(SDL.InitFlags.Video))
@@ -60,7 +64,15 @@ partial class Program
         if (window == null)
             throw new NullReferenceException("Window instance == null after DI resolution.");
 
-        window.Name = "Window";
+        DiagnosticXMLSink? sink = PhotonDiagnostics.Sink as DiagnosticXMLSink;
+
+        sink?
+            .SetHeader("<PhotonDiagnostics>")
+            .SetFooter("</PhotonDiagnostics>")
+            .ResetOutput()
+            .Start();
+
+        window.Name = "Root";
         window.Child = (Border)view;
         window.Child.DataContext = viewModel;
         window.Initialize("PhotonUI :: Demo", new Size(800, 600), SDL.WindowFlags.Resizable);

--- a/PhotonUI.Desktop/Views/MainView.cs
+++ b/PhotonUI.Desktop/Views/MainView.cs
@@ -13,7 +13,7 @@ namespace PhotonUI.Desktop.Views
     {
         protected readonly ITextureService TexureService = textureService;
 
-        public override void OnInitialize(Window window)
+        public override void FrameworkInitialize(Window window)
         {
             this.TexureService.LoadEmbeddedSurface("PhotonUI.Desktop.Assets.Images.sdl_logo.png", "sdl_logo");
 
@@ -34,6 +34,8 @@ namespace PhotonUI.Desktop.Views
             textBlock.MinWidth = 230;
 
             this.Child = textBlock;
+
+            base.FrameworkInitialize(window);
         }
     }
 }

--- a/PhotonUI.sln
+++ b/PhotonUI.sln
@@ -9,17 +9,22 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Diagnose|Any CPU = Diagnose|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{093A348C-A7EA-4E8C-063B-6FEECF70E3D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{093A348C-A7EA-4E8C-063B-6FEECF70E3D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{093A348C-A7EA-4E8C-063B-6FEECF70E3D3}.Diagnose|Any CPU.ActiveCfg = Diagnose|Any CPU
+		{093A348C-A7EA-4E8C-063B-6FEECF70E3D3}.Diagnose|Any CPU.Build.0 = Diagnose|Any CPU
 		{093A348C-A7EA-4E8C-063B-6FEECF70E3D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{093A348C-A7EA-4E8C-063B-6FEECF70E3D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Diagnose|Any CPU.ActiveCfg = Diagnose|Any CPU
+		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Diagnose|Any CPU.Build.0 = Diagnose|Any CPU
+		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{557BBE31-6B11-8107-489C-7D4CD5BDD9A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PhotonUI/Controls/Canvas.cs
+++ b/PhotonUI/Controls/Canvas.cs
@@ -1,4 +1,8 @@
-﻿using PhotonUI.Events.Framework;
+﻿using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
+using PhotonUI.Events.Framework;
 using PhotonUI.Extensions;
 using PhotonUI.Interfaces.Services;
 using PhotonUI.Models;
@@ -67,28 +71,39 @@ namespace PhotonUI.Controls
 
         public override bool TunnelControls(Func<Control, bool> traveler, TunnelDirection direction = TunnelDirection.TopDown)
         {
-            if (direction == TunnelDirection.TopDown)
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [traveler, direction], DiagnosticPhase.Start));
+
+            try
             {
-                if (!traveler(this)) return false;
+                if (direction == TunnelDirection.TopDown)
+                {
+                    if (!traveler(this)) return false;
 
-                if (this.Children != null)
-                    foreach (Control child in this.Children)
-                        if (!child.TunnelControls(traveler, direction)) return false;
+                    if (this.Children != null)
+                        foreach (Control child in this.Children)
+                            if (!child.TunnelControls(traveler, direction)) return false;
+                }
+                else
+                {
+                    if (this.Children != null)
+                        foreach (Control child in this.Children)
+                            if (!child.TunnelControls(traveler, direction)) return false;
+
+                    if (!traveler(this)) return false;
+                }
+
+                return true;
             }
-            else
+            finally
             {
-                if (this.Children != null)
-                    foreach (Control child in this.Children)
-                        if (!child.TunnelControls(traveler, direction)) return false;
-
-                if (!traveler(this)) return false;
+                PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [traveler, direction], DiagnosticPhase.End));
             }
-
-            return true;
         }
 
         public override void FrameworkIntrinsic(Window window, Size content)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, content], DiagnosticPhase.Start));
+
             // Initialize extreme values for bounding box calculations
             float minX = float.PositiveInfinity;
             float maxX = float.NegativeInfinity;
@@ -122,9 +137,13 @@ namespace PhotonUI.Controls
 
             // Set the intrinsic size of the control based on the children's layout
             this.IntrinsicSize = Photon.GetMinimumSize(this, offsetEnvelope);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, content], DiagnosticPhase.End));
         }
         public override void FrameworkMeasure(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             foreach (Control child in this.Children)
             {
                 Size stretchedSize = Photon.GetStretchedSize(this, child);
@@ -134,9 +153,13 @@ namespace PhotonUI.Controls
 
                 child.OnMeasure(window);
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
         public override void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, anchor], DiagnosticPhase.Start));
+
             base.FrameworkArrange(window, anchor);
 
             foreach (Control child in this.Children)
@@ -146,9 +169,13 @@ namespace PhotonUI.Controls
                 // Arrange child based on computed anchor point
                 child.OnArrange(window, childAnchor);
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, anchor], DiagnosticPhase.End));
         }
         public override void FrameworkRender(Window window, SDL.Rect? clipRect)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.Start));
+
             // Skip rendering if the control is not visible
             if (this.IsVisible)
             {
@@ -176,8 +203,12 @@ namespace PhotonUI.Controls
 
                     // Restore the original clip region
                     Photon.ApplyControlClipRect(window, clipRect);
+
+                    PhotonDiagnostics.Emit(new RenderControlEventArgs(this));
                 }
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.End));
         }
 
         #endregion
@@ -186,11 +217,18 @@ namespace PhotonUI.Controls
 
         public override void OnInitialize(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             if (!this.IsInitialized)
+            {
                 this.FrameworkInitialize(window);
+                this.IsInitialized = true;
+            }
 
             foreach (Control child in this.Children)
                 child?.OnInitialize(window);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
 
         #endregion

--- a/PhotonUI/Controls/Content/ImageBlock.cs
+++ b/PhotonUI/Controls/Content/ImageBlock.cs
@@ -1,4 +1,8 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
 using PhotonUI.Interfaces;
 using PhotonUI.Interfaces.Services;
 using PhotonUI.Models;
@@ -19,6 +23,8 @@ namespace PhotonUI.Controls.Content
         protected Size SourceTextureSize = Size.Empty;
         protected Size SourceControlSize = Size.Empty;
 
+        #region ImageBlock: Style Properties
+
         [ObservableProperty] private string imageSourceName = ImageProperties.Default.ImageSourceName;
         [ObservableProperty] private SDL.FRect? imageSourceRect = ImageProperties.Default.ImageSourceRect;
         [ObservableProperty] private SDL.Color imageTintColor = ImageProperties.Default.ImageTintColor;
@@ -27,7 +33,9 @@ namespace PhotonUI.Controls.Content
         [ObservableProperty] private StretchMode stretchMode = StretchProperties.Default.StretchMode;
         [ObservableProperty] private StretchDirection stretchDirection = StretchProperties.Default.StretchDirection;
 
-        #region Image: Framework
+        #endregion
+
+        #region ImageBlock: Framework
 
         public override void ApplyStyles(params IStyleProperties[] properties)
         {
@@ -65,6 +73,8 @@ namespace PhotonUI.Controls.Content
 
         public override void FrameworkRender(Window window, SDL.Rect? clipRect)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.Start));
+
             if (this.IsVisible)
             {
                 Photon.GetControlClipRect(this.DrawRect, this.ClipToBounds, clipRect, out SDL.Rect? effectiveClipRect);
@@ -100,18 +110,24 @@ namespace PhotonUI.Controls.Content
                     Photon.ApplyControlClipRect(window, clipRect);
 
                     this.RenderedAction?.Invoke(this);
+
+                    PhotonDiagnostics.Emit(new RenderControlEventArgs(this));
                 }
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.End));
         }
 
         #endregion
 
-        #region Image: Hooks
+        #region ImageBlock: Hooks
 
         protected override void OnPropertyChanged(PropertyChangedEventArgs e)
         {
             if (!this.IsInitialized)
                 return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.Start));
 
             base.OnPropertyChanged(e);
 
@@ -139,14 +155,20 @@ namespace PhotonUI.Controls.Content
 
             if (invalidateRender)
                 this.RequestRenderWithFlags(imageDirty: invalidateImage);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.End));
         }
 
         public override void OnInitialize(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             base.OnInitialize(window);
 
             if (this.LoadSourceTexture(window))
                 this.RebuildTexture(window);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
 
         public override void Dispose()
@@ -165,7 +187,7 @@ namespace PhotonUI.Controls.Content
 
         #endregion
 
-        #region Image: Helpers
+        #region ImageBlock: Helpers
 
         protected virtual void RebuildTexture(Window window)
         {

--- a/PhotonUI/Controls/Content/SpriteBlock.cs
+++ b/PhotonUI/Controls/Content/SpriteBlock.cs
@@ -1,5 +1,9 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using PhotonUI.Components;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
 using PhotonUI.Interfaces;
 using PhotonUI.Interfaces.Services;
 using PhotonUI.Models;
@@ -114,6 +118,8 @@ namespace PhotonUI.Controls.Content
             if (!this.IsInitialized)
                 return;
 
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.Start));
+
             base.OnPropertyChanged(e);
 
             bool invalidateMeasure = false;
@@ -172,18 +178,26 @@ namespace PhotonUI.Controls.Content
 
             if (invalidateRender)
                 this.RequestRenderWithFlags();
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.End));
         }
 
         public override void OnInitialize(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             base.OnInitialize(window);
 
             if (this.TryLoadPlayer(window))
                 if (this.Player != null)
                     this.IsPlayerDirty = false;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
         public override void OnTick(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             base.OnTick(window);
 
             if (this.IsImageDirty)
@@ -216,9 +230,13 @@ namespace PhotonUI.Controls.Content
                 this.RebuildTexture(window, frame, currentIndex);
                 this.RequestRender(invalidate: true);
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
         public override void OnRender(Window window, SDL.Rect? clipRect = null)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.Start));
+
             if (this.IsRenderDirty)
             {
                 if (this.IsVisible)
@@ -246,12 +264,16 @@ namespace PhotonUI.Controls.Content
                         }
 
                         Photon.ApplyControlClipRect(window, clipRect);
+
+                        PhotonDiagnostics.Emit(new RenderControlEventArgs(this, DiagnosticPhase.Start));
                     }
                 }
 
                 this.IsRenderDirty = false;
                 this.RenderedAction?.Invoke(this);
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.End));
         }
 
         public override void Dispose()

--- a/PhotonUI/Controls/Content/TextBlock.cs
+++ b/PhotonUI/Controls/Content/TextBlock.cs
@@ -1,5 +1,9 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using PhotonUI.Behaviors;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
 using PhotonUI.Events;
 using PhotonUI.Events.Platform;
 using PhotonUI.Extensions;
@@ -181,12 +185,15 @@ namespace PhotonUI.Controls.Content
         }
         public override void FrameworkRender(Window window, SDL.Rect? clipRect = null)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.Start));
+
             if (this.IsVisible)
             {
                 Photon.GetControlClipRect(this.DrawRect, this.ClipToBounds, clipRect, out SDL.Rect? effectiveClipRect);
 
                 if (effectiveClipRect.HasValue)
                 {
+
                     if (this.IsTextDirty)
                     {
                         this.RebuildTextureCache(window, this.FromControl<TextProperties>());
@@ -202,8 +209,12 @@ namespace PhotonUI.Controls.Content
                     this.ScrollbarBehavior.OnRender(window, this.DrawRect.ToRect());
 
                     Photon.ApplyControlClipRect(window, clipRect);
+
+                    PhotonDiagnostics.Emit(new RenderControlEventArgs(this));
                 }
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.End));
         }
 
         #endregion
@@ -289,13 +300,19 @@ namespace PhotonUI.Controls.Content
 
         public override void OnInitialize(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             this.RebuildFont();
 
             base.OnInitialize(window);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
         public override void OnEvent(Window window, FrameworkEventArgs e)
         {
             if (e.Handled == true || e.Preview == true) return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, e], DiagnosticPhase.Start));
 
             if (e is PlatformEventArgs platformEvent)
                 this.ScrollbarBehavior?.OnEvent(window, platformEvent.NativeEvent);
@@ -312,6 +329,8 @@ namespace PhotonUI.Controls.Content
                     pointerExited.Handled = true;
                     break;
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, e], DiagnosticPhase.End));
         }
 
         public override void Dispose()

--- a/PhotonUI/Controls/Control.cs
+++ b/PhotonUI/Controls/Control.cs
@@ -1,4 +1,8 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
 using PhotonUI.Events;
 using PhotonUI.Events.Framework;
 using PhotonUI.Events.Platform;
@@ -250,9 +254,15 @@ namespace PhotonUI.Controls
         }
 
         public virtual bool TunnelControls(Func<Control, bool> tunneler, TunnelDirection direction = TunnelDirection.TopDown)
-            => tunneler(this);
+        {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [tunneler, direction]));
+
+            return tunneler(this);
+        }
         public virtual bool BubbleControls(Func<Control, bool> bubbler)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [bubbler]));
+
             if (!bubbler(this))
                 return false;
 
@@ -266,23 +276,33 @@ namespace PhotonUI.Controls
 
         public virtual void RequestMeasure()
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
+
             this.TunnelControls(control =>
             {
                 control.IsIntrinsicDirty = true;
                 control.IsMeasureDirty = true;
                 return true;
             });
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         public virtual void RequestArrange()
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
+
             this.TunnelControls(control =>
             {
                 control.IsLayoutDirty = true;
                 return true;
             });
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         public virtual void RequestRender(bool invalidate = true)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [invalidate], DiagnosticPhase.Start));
+
             this.IsRenderDirty = true;
 
             if (invalidate)
@@ -294,23 +314,34 @@ namespace PhotonUI.Controls
                     control.RequestRender(false);
                 return true;
             });
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [invalidate], DiagnosticPhase.End));
         }
 
         public virtual void FrameworkEventBubble(Window window, FrameworkEventArgs e)
         {
-            if (!this.IsInitialized)
-                return;
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, e], DiagnosticPhase.Start));
 
-            this.OnEvent(window, e);
-
-            this.BubbleControls(control =>
+            try
             {
-                if (!control.IsInitialized)
-                    return true;
+                if (!this.IsInitialized)
+                    return;
 
-                control.OnEvent(window, e);
-                return true;
-            });
+                this.OnEvent(window, e);
+
+                this.BubbleControls(control =>
+                {
+                    if (!control.IsInitialized)
+                        return true;
+
+                    control.OnEvent(window, e);
+                    return true;
+                });
+            }
+            finally
+            {
+                PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, e], DiagnosticPhase.End));
+            }
         }
 
         public virtual void FrameworkInitialize(Window window)
@@ -319,31 +350,35 @@ namespace PhotonUI.Controls
 
             if (!this.IsInitialized)
             {
-                this.IsInitialized = true;
-
-                this.OnInitialize(window);
-
                 if (this.IsFocused)
                     window.SetFocus(this);
 
                 this.InitializedAction?.Invoke(this);
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window]));
         }
         public virtual void FrameworkTick(Window window) { }
         public virtual void FrameworkIntrinsic(Window window, Size content)
         {
             // Set the intrinsic size to the minimum size for this control
             this.IntrinsicSize = Photon.GetMinimumSize(this);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, content]));
         }
         public virtual void FrameworkMeasure(Window window) { }
         public virtual void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
             this.DrawRect.X = anchor.X + this.X;
             this.DrawRect.Y = anchor.Y + this.Y;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, anchor]));
         }
         public virtual void FrameworkLateTick(Window window) { }
         public virtual void FrameworkRender(Window window, SDL.Rect? clipRect)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.Start));
+
             // Skip rendering if control is not visible
             if (this.IsVisible)
             {
@@ -361,8 +396,12 @@ namespace PhotonUI.Controls
 
                     // Restore the original clip region
                     Photon.ApplyControlClipRect(window, clipRect);
+
+                    PhotonDiagnostics.Emit(new RenderControlEventArgs(this));
                 }
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.End));
         }
         public virtual void FrameworkPostTick(Window window) { }
 
@@ -374,6 +413,8 @@ namespace PhotonUI.Controls
         {
             if (!this.IsInitialized)
                 return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.Start));
 
             base.OnPropertyChanged(e);
 
@@ -418,20 +459,35 @@ namespace PhotonUI.Controls
                 this.RequestRender(true);
 
             this.FrameworkEventBubble(Photon.GetWindow(this), new ChildPropertyChangedEventArgs(this, e));
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.End));
         }
 
         public virtual void OnInitialize(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             if (!this.IsInitialized)
+            {
                 this.FrameworkInitialize(window);
+                this.IsInitialized = true;
+            }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
         public virtual void OnTick(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             this.FrameworkTick(window);
             this.TickAction?.Invoke(this);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
         public virtual void OnIntrinsic(Window window, Size content)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, content], DiagnosticPhase.Start));
+
             if (this.IsIntrinsicDirty)
             {
                 this.FrameworkIntrinsic(window, content);
@@ -439,9 +495,13 @@ namespace PhotonUI.Controls
                 this.IntrinsicAction?.Invoke(this);
                 this.IsIntrinsicDirty = false;
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, content], DiagnosticPhase.End));
         }
         public virtual void OnMeasure(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             if (this.IsMeasureDirty)
             {
                 this.FrameworkMeasure(window);
@@ -449,9 +509,13 @@ namespace PhotonUI.Controls
                 this.MeasuredAction?.Invoke(this);
                 this.IsMeasureDirty = false;
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
         public virtual void OnArrange(Window window, SDL.FPoint anchor)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, anchor], DiagnosticPhase.Start));
+
             if (this.IsLayoutDirty)
             {
                 this.FrameworkArrange(window, anchor);
@@ -459,14 +523,22 @@ namespace PhotonUI.Controls
                 this.ArrangedAction?.Invoke(this);
                 this.IsLayoutDirty = false;
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, anchor], DiagnosticPhase.End));
         }
         public virtual void OnLateTick(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             this.FrameworkLateTick(window);
             this.LateTickAction?.Invoke(this);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
         public virtual void OnRender(Window window, SDL.Rect? clipRect = null)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [clipRect], DiagnosticPhase.Start));
+
             if (this.IsRenderDirty)
             {
                 this.FrameworkRender(window, clipRect);
@@ -474,12 +546,19 @@ namespace PhotonUI.Controls
                 this.RenderedAction?.Invoke(this);
                 this.IsRenderDirty = false;
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [clipRect], DiagnosticPhase.End));
         }
         public virtual void OnPostTick(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             this.FrameworkPostTick(window);
             this.PostTickAction?.Invoke(this);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
+
         public virtual void OnEvent(Window window, FrameworkEventArgs e)
         {
             if (e.Handled || e.Preview) return;
@@ -508,6 +587,8 @@ namespace PhotonUI.Controls
                     this.PointerPressAction?.Invoke(pointerPress);
                     break;
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, e]));
         }
 
         public virtual void Dispose()

--- a/PhotonUI/Controls/Decorators/Border.cs
+++ b/PhotonUI/Controls/Decorators/Border.cs
@@ -1,4 +1,8 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
 using PhotonUI.Interfaces;
 using PhotonUI.Interfaces.Services;
 using PhotonUI.Models;
@@ -11,11 +15,15 @@ namespace PhotonUI.Controls.Decorators
     public partial class Border(IServiceProvider serviceProvider, IBindingService bindingService)
         : Presenter(serviceProvider, bindingService), IBorderProperties
     {
+        public override Thickness PaddingExtent
+            => this.Padding + this.BorderThickness;
+
+        #region Border: Style Properties
+
         [ObservableProperty] private BorderColors borderColors = BorderProperties.Default.BorderColors;
         [ObservableProperty] private Thickness borderThickness = BorderProperties.Default.BorderThickness;
 
-        public override Thickness PaddingExtent
-            => this.Padding + this.BorderThickness;
+        #endregion
 
         #region Border: Framework
 
@@ -38,6 +46,8 @@ namespace PhotonUI.Controls.Decorators
 
         public override void FrameworkRender(Window window, SDL.Rect? clipRect)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.Start));
+
             // Skip rendering if control is not visible
             if (!this.IsVisible) return;
 
@@ -58,7 +68,11 @@ namespace PhotonUI.Controls.Decorators
 
                 // Restore the original clip region
                 Photon.ApplyControlClipRect(window, clipRect);
+
+                PhotonDiagnostics.Emit(new RenderControlEventArgs(this));
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.End));
         }
 
         #endregion
@@ -69,6 +83,8 @@ namespace PhotonUI.Controls.Decorators
         {
             if (!this.IsInitialized)
                 return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.Start));
 
             base.OnPropertyChanged(e);
 
@@ -97,6 +113,8 @@ namespace PhotonUI.Controls.Decorators
 
             if (invalidateRender)
                 this.RequestRender();
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.End));
         }
 
         #endregion

--- a/PhotonUI/Controls/Interaction/ClickSurface.cs
+++ b/PhotonUI/Controls/Interaction/ClickSurface.cs
@@ -1,5 +1,9 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using PhotonUI.Controls.Decorators;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
 using PhotonUI.Events;
 using PhotonUI.Events.Platform;
 using PhotonUI.Extensions;
@@ -18,6 +22,8 @@ namespace PhotonUI.Controls.Interaction
         protected bool IsHovering = false;
         protected bool IsPressed = false;
 
+        #region ClickSurface: Style Properties
+
         [ObservableProperty] private BorderColors borderColors = BorderProperties.Default.BorderColors;
         [ObservableProperty] private Thickness borderThickness = BorderProperties.Default.BorderThickness;
 
@@ -28,9 +34,13 @@ namespace PhotonUI.Controls.Interaction
         [ObservableProperty] private float pressedOpacity = PressedProperties.Default.PressedOpacity;
         [ObservableProperty] private float pressedScale = PressedProperties.Default.PressedScale;
 
+        #endregion
+
+        #region ClickSurface: Actions
+
         public Action<PointerClickEventArgs>? OnClickAction { get; set; }
 
-        public ICommand? OnClick { get; set; }
+        #endregion
 
         #region ClickSurface: Framework
 
@@ -57,6 +67,8 @@ namespace PhotonUI.Controls.Interaction
 
         public override void FrameworkRender(Window window, SDL.Rect? clipRect = null)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.Start));
+
             if (this.IsVisible)
             {
                 Photon.GetControlClipRect(this.DrawRect, this.ClipToBounds, clipRect, out SDL.Rect? effectiveClipRect);
@@ -73,63 +85,79 @@ namespace PhotonUI.Controls.Interaction
                     this.Child?.OnRender(window, modifiedClipRect);
 
                     Photon.ApplyControlClipRect(window, clipRect);
+
+                    PhotonDiagnostics.Emit(new RenderControlEventArgs(this));
                 }
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.End));
         }
         #endregion
 
         #region ClickSurface: Hooks
 
+        public ICommand? OnClick { get; set; }
+
         public override void OnEvent(Window window, FrameworkEventArgs e)
         {
             if (e.Handled || e.Preview) return;
 
-            base.OnEvent(window, e);
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, e], DiagnosticPhase.Start));
 
-            switch (e)
+            try
             {
-                case PointerEnterEventArgs:
-                    this.IsHovering = true;
-                    this.RequestRender();
-                    e.Handled = true;
-                    break;
+                base.OnEvent(window, e);
 
-                case PointerExitEventArgs:
-                    this.IsHovering = false;
-                    this.RequestRender();
-                    e.Handled = true;
-                    break;
-            }
-
-            if (e is not PointerClickEventArgs pointerPress) return;
-
-            switch (pointerPress.NativeEvent.Type)
-            {
-                case (uint)SDL.EventType.MouseButtonDown:
-                    if (pointerPress.Clicked == this || this.IsDescendant(pointerPress.Clicked))
-                    {
-                        this.IsPressed = true;
+                switch (e)
+                {
+                    case PointerEnterEventArgs:
+                        this.IsHovering = true;
                         this.RequestRender();
-                        window.CapturePointer(this);
                         e.Handled = true;
-                    }
-                    break;
+                        break;
 
-                case (uint)SDL.EventType.MouseButtonUp:
-                    if (pointerPress.Clicked == this || this.IsDescendant(pointerPress.Clicked))
-                    {
-                        if (this.IsHovering && this.IsPressed)
+                    case PointerExitEventArgs:
+                        this.IsHovering = false;
+                        this.RequestRender();
+                        e.Handled = true;
+                        break;
+                }
+
+                if (e is not PointerClickEventArgs pointerPress) return;
+
+                switch (pointerPress.NativeEvent.Type)
+                {
+                    case (uint)SDL.EventType.MouseButtonDown:
+                        if (pointerPress.Clicked == this || this.IsDescendant(pointerPress.Clicked))
                         {
-                            this.OnClick?.Execute(pointerPress);
-                            this.OnClickAction?.Invoke(pointerPress);
+                            this.IsPressed = true;
+                            this.RequestRender();
+                            window.CapturePointer(this);
+                            e.Handled = true;
                         }
+                        break;
 
-                        this.IsPressed = false;
-                        this.RequestRender();
-                        window.ReleasePointer();
-                        e.Handled = true;
-                    }
-                    break;
+                    case (uint)SDL.EventType.MouseButtonUp:
+                        if (pointerPress.Clicked == this || this.IsDescendant(pointerPress.Clicked))
+                        {
+                            if (this.IsHovering && this.IsPressed)
+                            {
+                                this.OnClick?.Execute(pointerPress);
+                                this.OnClickAction?.Invoke(pointerPress);
+                            }
+
+                            this.IsPressed = false;
+                            this.RequestRender();
+                            window.ReleasePointer();
+                            e.Handled = true;
+                        }
+                        break;
+                }
+
+            }
+            finally
+            {
+                PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, e], DiagnosticPhase.End));
             }
         }
 

--- a/PhotonUI/Controls/Layout/StackBlock.cs
+++ b/PhotonUI/Controls/Layout/StackBlock.cs
@@ -1,4 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
 using PhotonUI.Extensions;
 using PhotonUI.Interfaces;
 using PhotonUI.Interfaces.Services;
@@ -147,6 +150,8 @@ namespace PhotonUI.Controls.Layout
             if (!this.IsInitialized)
                 return;
 
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.Start));
+
             base.OnPropertyChanged(e);
 
             bool invalidateMeasure = false;
@@ -170,6 +175,8 @@ namespace PhotonUI.Controls.Layout
 
             if (invalidateRender)
                 this.RequestRender();
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.End));
         }
 
         #endregion

--- a/PhotonUI/Controls/Presenter.cs
+++ b/PhotonUI/Controls/Presenter.cs
@@ -1,4 +1,8 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
 using PhotonUI.Events.Framework;
 using PhotonUI.Extensions;
 using PhotonUI.Interfaces.Services;
@@ -49,22 +53,33 @@ namespace PhotonUI.Controls
 
         public override bool TunnelControls(Func<Control, bool> traveler, TunnelDirection direction = TunnelDirection.TopDown)
         {
-            if (direction == TunnelDirection.TopDown)
-            {
-                if (!traveler(this)) return false;
-                if (this.Child != null && !this.Child.TunnelControls(traveler, direction)) return false;
-            }
-            else
-            {
-                if (this.Child != null && !this.Child.TunnelControls(traveler, direction)) return false;
-                if (!traveler(this)) return false;
-            }
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [traveler, direction], DiagnosticPhase.Start));
 
-            return true;
+            try
+            {
+                if (direction == TunnelDirection.TopDown)
+                {
+                    if (!traveler(this)) return false;
+                    if (this.Child != null && !this.Child.TunnelControls(traveler, direction)) return false;
+                }
+                else
+                {
+                    if (this.Child != null && !this.Child.TunnelControls(traveler, direction)) return false;
+                    if (!traveler(this)) return false;
+                }
+
+                return true;
+            }
+            finally
+            {
+                PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [traveler, direction], DiagnosticPhase.End));
+            }
         }
 
         public override void FrameworkIntrinsic(Window window, Size content)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, content], DiagnosticPhase.Start));
+
             Size? childSize = null;
 
             if (this.Child != null)
@@ -81,9 +96,13 @@ namespace PhotonUI.Controls
             // Calculate the intrinsic size, but only if not a Window (for base controls)
             if (this.GetType() != typeof(Window))
                 this.IntrinsicSize = Photon.GetMinimumSize(this, childSize);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, content], DiagnosticPhase.End));
         }
         public override void FrameworkMeasure(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             if (this.Child != null)
             {
                 Size stretchedSize = Photon.GetStretchedSize(this, this.Child);
@@ -93,9 +112,13 @@ namespace PhotonUI.Controls
 
                 this.Child.OnMeasure(window);
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
         public override void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, anchor], DiagnosticPhase.Start));
+
             base.FrameworkArrange(window, anchor);
 
             if (this.Child != null)
@@ -105,9 +128,13 @@ namespace PhotonUI.Controls
                 // Arrange child based on computed anchor point
                 this.Child.OnArrange(window, childAnchor);
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, anchor], DiagnosticPhase.End));
         }
         public override void FrameworkRender(Window window, SDL.Rect? clipRect)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.Start));
+
             // Skip rendering if control is not visible
             if (this.IsVisible)
             {
@@ -134,20 +161,31 @@ namespace PhotonUI.Controls
 
                     // Restore the original clip region
                     Photon.ApplyControlClipRect(window, clipRect);
+
+                    PhotonDiagnostics.Emit(new RenderControlEventArgs(this));
                 }
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.End));
         }
 
         #endregion
 
-        #region Control: Hooks
+        #region Presenter: Hooks
 
         public override void OnInitialize(Window window)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
             if (!this.IsInitialized)
+            {
                 this.FrameworkInitialize(window);
+                this.IsInitialized = true;
+            }
 
             this.Child?.OnInitialize(window);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
         }
 
         #endregion

--- a/PhotonUI/Controls/Viewport/ScrollBlock.cs
+++ b/PhotonUI/Controls/Viewport/ScrollBlock.cs
@@ -1,5 +1,9 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using PhotonUI.Behaviors;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
 using PhotonUI.Events;
 using PhotonUI.Events.Platform;
 using PhotonUI.Extensions;
@@ -91,14 +95,20 @@ namespace PhotonUI.Controls.Viewport
 
         public override void RequestRender(bool invalidate = true)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [invalidate], DiagnosticPhase.Start));
+
             this.IsRenderDirty = true;
             this.ScrollbarBehavior.RequestRender();
 
             if (invalidate)
                 Photon.InvalidateRenderChain(this);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [invalidate], DiagnosticPhase.End));
         }
         public virtual void RequestRenderWithFlags(bool scrollbarDirty = false, bool invalidate = true)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [invalidate], DiagnosticPhase.Start));
+
             this.IsRenderDirty = true;
 
             if (scrollbarDirty == true)
@@ -106,10 +116,14 @@ namespace PhotonUI.Controls.Viewport
 
             if (invalidate)
                 Photon.InvalidateRenderChain(this);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [invalidate], DiagnosticPhase.End));
         }
 
         public override void FrameworkIntrinsic(Window window, Size content)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, content], DiagnosticPhase.Start));
+
             if (this.Child != null)
             {
                 Size childContent = content.Deflate(this.PaddingExtent).Deflate(this.Child.MarginExtent);
@@ -120,9 +134,13 @@ namespace PhotonUI.Controls.Viewport
 
             // Calculate the intrinsic size
             this.IntrinsicSize = Photon.GetMinimumSize(this);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, content], DiagnosticPhase.End));
         }
         public override void FrameworkArrange(Window window, SDL.FPoint anchor)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, anchor], DiagnosticPhase.Start));
+
             this.DrawRect.X = anchor.X + this.X;
             this.DrawRect.Y = anchor.Y + this.Y;
 
@@ -138,9 +156,13 @@ namespace PhotonUI.Controls.Viewport
 
                 this.Child.OnArrange(window, new SDL.FPoint() { X = this.Child.DrawRect.X, Y = this.Child.DrawRect.Y });
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, anchor], DiagnosticPhase.End));
         }
         public override void FrameworkRender(Window window, SDL.Rect? clipRect = null)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.Start));
+
             if (this.IsVisible)
             {
                 // Compute effective clip rect: intersection of parent clip, control bounds, and ClipToBounds
@@ -165,8 +187,12 @@ namespace PhotonUI.Controls.Viewport
 
                     // Restore parent clip state (unwind clipping stack)
                     Photon.ApplyControlClipRect(window, clipRect);
+
+                    PhotonDiagnostics.Emit(new RenderControlEventArgs(this));
                 }
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, clipRect], DiagnosticPhase.End));
         }
 
         #endregion
@@ -177,6 +203,8 @@ namespace PhotonUI.Controls.Viewport
         {
             if (!this.IsInitialized)
                 return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.Start));
 
             base.OnPropertyChanged(e);
 
@@ -202,11 +230,15 @@ namespace PhotonUI.Controls.Viewport
 
             if (invalidateRender)
                 this.RequestRender();
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [e], DiagnosticPhase.End));
         }
 
         public override void OnEvent(Window window, FrameworkEventArgs e)
         {
             if (e.Handled == true || e.Preview == true) return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, e], DiagnosticPhase.Start));
 
             if (e is PlatformEventArgs platformEvent)
                 this.ScrollbarBehavior?.OnEvent(window, platformEvent.NativeEvent);
@@ -223,6 +255,8 @@ namespace PhotonUI.Controls.Viewport
                     pointerExited.Handled = true;
                     break;
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window, e], DiagnosticPhase.End));
         }
 
         #endregion

--- a/PhotonUI/Controls/Window.cs
+++ b/PhotonUI/Controls/Window.cs
@@ -1,4 +1,8 @@
 ﻿using PhotonUI.Animations;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
+using PhotonUI.Diagnostics.Events.Platform;
 using PhotonUI.Events;
 using PhotonUI.Events.Framework;
 using PhotonUI.Events.Platform;
@@ -78,6 +82,8 @@ namespace PhotonUI.Controls
         }
         public virtual void Tick()
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
+
             this.ApplyTick();
             this.ApplyAnimationRequests();
             this.ApplyIntrinsicRequests();
@@ -96,32 +102,45 @@ namespace PhotonUI.Controls
                 SDL.RenderClear(this.Renderer);
                 SDL.RenderTexture(this.Renderer, this.BackTexture, IntPtr.Zero, IntPtr.Zero);
                 SDL.RenderPresent(this.Renderer);
+
+                PhotonDiagnostics.Emit(new RenderPresentEventArgs(this));
             }
 
             this.ApplyPostTick();
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         public virtual void Event(SDL.Event e)
         {
-            SDL.EventType eventType = (SDL.EventType)e.Type;
+            PhotonDiagnostics.Emit(new PlatformEventEventArgs(new PlatformEventArgs(e), DiagnosticPhase.Start));
 
-            switch (eventType)
+            try
             {
-                case SDL.EventType.MouseMotion:
-                    this.PointerMotionHandler(this, e);
-                    this.GetFocusedControl(e.Motion)?.OnEvent(this, new PlatformEventArgs(e));
-                    return;
+                SDL.EventType eventType = (SDL.EventType)e.Type;
 
-                case SDL.EventType.MouseButtonDown:
-                case SDL.EventType.MouseButtonUp:
-                    this.PointerButtonHandler(this, e);
-                    this.GetFocusedControl(e.Motion)?.OnEvent(this, new PlatformEventArgs(e));
-                    return;
+                switch (eventType)
+                {
+                    case SDL.EventType.MouseMotion:
+                        this.PointerMotionHandler(this, e);
+                        this.GetFocusedControl(e.Motion)?.OnEvent(this, new PlatformEventArgs(e));
+                        return;
 
-                case SDL.EventType.TextInput:
-                    break;
+                    case SDL.EventType.MouseButtonDown:
+                    case SDL.EventType.MouseButtonUp:
+                        this.PointerButtonHandler(this, e);
+                        this.GetFocusedControl(e.Motion)?.OnEvent(this, new PlatformEventArgs(e));
+                        return;
+
+                    case SDL.EventType.TextInput:
+                        break;
+                }
+
+                this.KeyboardInputTarget.OnEvent(this, new PlatformEventArgs(e));
             }
-
-            this.KeyboardInputTarget.OnEvent(this, new PlatformEventArgs(e));
+            finally
+            {
+                PhotonDiagnostics.Emit(new PlatformEventEventArgs(new PlatformEventArgs(e), DiagnosticPhase.End));
+            }
         }
 
         public void GetScreenshot(string path)
@@ -173,9 +192,18 @@ namespace PhotonUI.Controls
         }
         public Control GetFocusedControl(SDL.MouseMotionEvent motion)
         {
-            Control? c = Photon.ResolveHitControl(this, motion.X, motion.Y);
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [motion], DiagnosticPhase.Start));
 
-            return this.PointerCapturedControl ?? c ?? this;
+            try
+            {
+                Control? c = Photon.ResolveHitControl(this, motion.X, motion.Y);
+
+                return this.PointerCapturedControl ?? c ?? this;
+            }
+            finally
+            {
+                PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [motion], DiagnosticPhase.End));
+            }
         }
 
         #endregion
@@ -186,12 +214,18 @@ namespace PhotonUI.Controls
         {
             if (this.FocusedControl == control) return;
 
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [control], DiagnosticPhase.Start));
+
             this.FocusedControl?.OnEvent(this, new FocusLostEventArgs(this.FocusedControl));
             this.FocusedControl = control;
             this.FocusedControl?.OnEvent(this, new FocusGainedEventArgs(this.FocusedControl));
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [control], DiagnosticPhase.End));
         }
         public virtual void SetWindowSize(int width, int height)
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [width, height], DiagnosticPhase.Start));
+
             if (this.BackTexture != IntPtr.Zero)
             {
                 SDL.DestroyTexture(this.BackTexture);
@@ -210,11 +244,15 @@ namespace PhotonUI.Controls
             this.RequestMeasure();
             this.RequestArrange();
             this.RequestRender();
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [width, height], DiagnosticPhase.End));
         }
         public virtual void SetRenderer(IntPtr renderer)
         {
             if (this.Renderer == renderer)
                 return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [renderer], DiagnosticPhase.Start));
 
             if (this.BackTexture != IntPtr.Zero)
             {
@@ -226,6 +264,8 @@ namespace PhotonUI.Controls
             this.Renderer = renderer;
 
             this.SetWindowSize((int)this.DrawRect.W, (int)this.DrawRect.H);
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [renderer], DiagnosticPhase.End));
         }
 
         public PropertyAnimation<TTarget, TProp> Animate<TTarget, TProp>(TTarget target, Expression<Func<TTarget, TProp>> selector)
@@ -273,28 +313,39 @@ namespace PhotonUI.Controls
 
         protected bool NeedsRendering()
         {
-            if (this.SuppressRendering)
-                return false;
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
 
-            bool needsRender = false;
-
-            this.TunnelControls((c) =>
+            try
             {
-                if (c.IsRenderDirty)
-                {
-                    needsRender = true;
-
+                if (this.SuppressRendering)
                     return false;
-                }
-                return true;
-            });
 
-            return needsRender;
+                bool needsRender = false;
+
+                this.TunnelControls((c) =>
+                {
+                    if (c.IsRenderDirty)
+                    {
+                        needsRender = true;
+
+                        return false;
+                    }
+                    return true;
+                });
+
+                return needsRender;
+            }
+            finally
+            {
+                PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
+            }
         }
 
         protected void ApplyTick()
         {
             if (this.Child == null) return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
 
             this.Child.TunnelControls((c) =>
             {
@@ -303,10 +354,14 @@ namespace PhotonUI.Controls
 
                 return true;
             });
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         protected void ApplyAnimationRequests()
         {
             if (this.ActiveAnimations.Count == 0) return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
 
             foreach (AnimationHandle? handle in this.ActiveAnimations.ToList())
             {
@@ -324,9 +379,13 @@ namespace PhotonUI.Controls
                 if (handle.State == AnimationState.Running)
                     handle.Update();
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         protected void ApplyIntrinsicRequests()
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
+
             this.TunnelControls(control =>
             {
                 if (control.IsIntrinsicDirty)
@@ -345,9 +404,13 @@ namespace PhotonUI.Controls
                 }
                 return true;
             });
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         protected void ApplyMeasureRequests()
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
+
             this.TunnelControls(control =>
             {
                 if (control.IsMeasureDirty)
@@ -366,9 +429,13 @@ namespace PhotonUI.Controls
                 }
                 return true;
             });
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         protected void ApplyArrangeRequests()
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
+
             this.TunnelControls(control =>
             {
                 if (control.IsLayoutDirty)
@@ -391,10 +458,14 @@ namespace PhotonUI.Controls
                 }
                 return true;
             });
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         protected void ApplyLateTick()
         {
             if (this.Child == null) return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
 
             this.Child.TunnelControls((c) =>
             {
@@ -403,9 +474,13 @@ namespace PhotonUI.Controls
 
                 return true;
             });
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         protected void ApplyRenderRequests()
         {
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
+
             this.TunnelControls(control =>
             {
                 if (control.IsRenderDirty)
@@ -431,10 +506,14 @@ namespace PhotonUI.Controls
 
                 return true;
             });
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         protected void ApplyPostTick()
         {
             if (this.Child == null) return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
 
             this.Child.TunnelControls((c) =>
             {
@@ -443,10 +522,14 @@ namespace PhotonUI.Controls
 
                 return true;
             });
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         protected void ApplyClearRequests()
         {
             if (this.Child == null) return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
 
             this.Child.TunnelControls((Func<Control, bool>)((c) =>
             {
@@ -461,6 +544,8 @@ namespace PhotonUI.Controls
                 }
                 return true;
             }));
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
 
         #endregion
@@ -471,6 +556,8 @@ namespace PhotonUI.Controls
         {
             if (e.Type != (uint)SDL.EventType.MouseMotion)
                 return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
 
             SDL.MouseMotionEvent motion = e.Motion;
 
@@ -487,12 +574,16 @@ namespace PhotonUI.Controls
                     focusSet = true;
                 }
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
         protected virtual void PointerButtonHandler(Window window, SDL.Event e)
         {
             if (e.Type != (uint)SDL.EventType.MouseButtonDown &&
                 e.Type != (uint)SDL.EventType.MouseButtonUp)
                 return;
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.Start));
 
             Control target = this.GetFocusedControl(e.Motion);
 
@@ -512,52 +603,62 @@ namespace PhotonUI.Controls
                 PointerClickEventArgs bubbleArgs = new(window, target, e);
                 target.FrameworkEventBubble(window, bubbleArgs);
             }
+
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, null, DiagnosticPhase.End));
         }
 
         #endregion
 
-        #region Control: Hooks
+        #region Window: Hooks
 
         public override void OnInitialize(Window window)
         {
             if (window.IsInitialized == true) return;
 
-            if (window.Mode == WindowMode.Tangible)
+            PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.Start));
+
+            try
             {
-                window.Handle = SDL.CreateWindow(
-                    window.DefaultTitle,
-                    (int)window.DefaultSize.Width,
-                    (int)window.DefaultSize.Height,
-                    window.DefaultFlags);
-
-                if (!window.HasTangibleWindow)
+                if (window.Mode == WindowMode.Tangible)
                 {
-                    SDL.Quit();
+                    window.Handle = SDL.CreateWindow(
+                        window.DefaultTitle,
+                        (int)window.DefaultSize.Width,
+                        (int)window.DefaultSize.Height,
+                        window.DefaultFlags);
 
-                    return;
+                    if (!window.HasTangibleWindow)
+                    {
+                        SDL.Quit();
+
+                        return;
+                    }
+
+                    window.Renderer = SDL.CreateRenderer(window.Handle, null);
+
+                    if (window.Renderer == IntPtr.Zero)
+                    {
+                        SDL.DestroyWindow(window.Handle);
+                        SDL.Quit();
+
+                        return;
+                    }
+
+                    SDL.GetWindowSize(window.Handle, out int width, out int height);
+
+                    window.SetWindowSize(width, height);
                 }
 
-                window.Renderer = SDL.CreateRenderer(window.Handle, null);
-
-                if (window.Renderer == IntPtr.Zero)
-                {
-                    SDL.DestroyWindow(window.Handle);
-                    SDL.Quit();
-
-                    return;
-                }
-
-                SDL.GetWindowSize(window.Handle, out int width, out int height);
-
-                window.SetWindowSize(width, height);
+                window.Name = window.Name;
+                window.HorizontalAlignment = Models.Properties.HorizontalAlignment.Stretch;
+                window.VerticalAlignment = Models.Properties.VerticalAlignment.Stretch;
+                window.IsInitialized = true;
+                window.Child?.OnInitialize(window);
             }
-
-            window.Name = window.Name;
-            window.HorizontalAlignment = Models.Properties.HorizontalAlignment.Stretch;
-            window.VerticalAlignment = Models.Properties.VerticalAlignment.Stretch;
-            window.IsInitialized = true;
-
-            window.Child?.OnInitialize(window);
+            finally
+            {
+                PhotonDiagnostics.Emit(new ControlMethodEventArgs(this, [window], DiagnosticPhase.End));
+            }
         }
 
         #endregion

--- a/PhotonUI/Diagnostics/Events/DiagnosticEventArgs.cs
+++ b/PhotonUI/Diagnostics/Events/DiagnosticEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+
+namespace PhotonUI.Diagnostics.Events
+{
+    public enum DiagnosticPhase
+    {
+        Start,
+        End,
+        Atomic
+    }
+
+    public abstract class DiagnosticEventArgs(DiagnosticPhase phase = DiagnosticPhase.Atomic)
+        : EventArgs
+    {
+        public MethodInfo? MethodInfo = null;
+        public StackFrame? StackFrame = null;
+
+        public DiagnosticPhase Phase { get; } = phase;
+    }
+}

--- a/PhotonUI/Diagnostics/Events/Framework/ControlEventArgs.cs
+++ b/PhotonUI/Diagnostics/Events/Framework/ControlEventArgs.cs
@@ -1,0 +1,10 @@
+﻿using PhotonUI.Controls;
+
+namespace PhotonUI.Diagnostics.Events.Framework
+{
+    public class ControlEventArgs(Control control, DiagnosticPhase phase = DiagnosticPhase.Atomic)
+        : DiagnosticEventArgs(phase)
+    {
+        public Control Control { get; } = control;
+    }
+}

--- a/PhotonUI/Diagnostics/Events/Framework/ControlMethodEventArgs.cs
+++ b/PhotonUI/Diagnostics/Events/Framework/ControlMethodEventArgs.cs
@@ -1,0 +1,10 @@
+﻿using PhotonUI.Controls;
+
+namespace PhotonUI.Diagnostics.Events.Framework
+{
+    public class ControlMethodEventArgs(Control control, List<object?>? parameters = null, DiagnosticPhase phase = DiagnosticPhase.Atomic)
+        : ControlEventArgs(control, phase)
+    {
+        public List<object?> Parameters { get; } = parameters ?? [];
+    }
+}

--- a/PhotonUI/Diagnostics/Events/Framework/PhotonMethodEventArgs.cs
+++ b/PhotonUI/Diagnostics/Events/Framework/PhotonMethodEventArgs.cs
@@ -1,0 +1,8 @@
+﻿namespace PhotonUI.Diagnostics.Events.Framework
+{
+    public class PhotonMethodEventArgs(List<object?>? parameters = null, DiagnosticPhase phase = DiagnosticPhase.Atomic)
+        : DiagnosticEventArgs(phase)
+    {
+        public List<object?> Parameters { get; } = parameters ?? [];
+    }
+}

--- a/PhotonUI/Diagnostics/Events/Platform/PlatformEventEventArgs.cs
+++ b/PhotonUI/Diagnostics/Events/Platform/PlatformEventEventArgs.cs
@@ -1,0 +1,10 @@
+﻿using PhotonUI.Events;
+
+namespace PhotonUI.Diagnostics.Events.Platform
+{
+    public class PlatformEventEventArgs(PlatformEventArgs e, DiagnosticPhase phase = DiagnosticPhase.Atomic)
+        : DiagnosticEventArgs(phase)
+    {
+        public PlatformEventArgs Event { get; } = e;
+    }
+}

--- a/PhotonUI/Diagnostics/Events/Platform/RenderControlEventArgs.cs
+++ b/PhotonUI/Diagnostics/Events/Platform/RenderControlEventArgs.cs
@@ -1,0 +1,9 @@
+﻿using PhotonUI.Controls;
+using PhotonUI.Diagnostics.Events.Framework;
+
+namespace PhotonUI.Diagnostics.Events.Platform
+{
+    public class RenderControlEventArgs(Control control, DiagnosticPhase phase = DiagnosticPhase.Atomic)
+        : ControlEventArgs(control, phase)
+    { }
+}

--- a/PhotonUI/Diagnostics/Events/Platform/RenderPresentEventArgs.cs
+++ b/PhotonUI/Diagnostics/Events/Platform/RenderPresentEventArgs.cs
@@ -1,0 +1,9 @@
+﻿using PhotonUI.Controls;
+using PhotonUI.Diagnostics.Events.Framework;
+
+namespace PhotonUI.Diagnostics.Events.Platform
+{
+    public class RenderPresentEventArgs(Control control, DiagnosticPhase phase = DiagnosticPhase.Atomic)
+        : ControlEventArgs(control, phase)
+    { }
+}

--- a/PhotonUI/Diagnostics/PhotonDiagnostics.cs
+++ b/PhotonUI/Diagnostics/PhotonDiagnostics.cs
@@ -1,0 +1,25 @@
+﻿using PhotonUI.Diagnostics.Events;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace PhotonUI.Diagnostics
+{
+    public interface IPhotonDiagnostics
+    {
+        void OnEvent(DiagnosticEventArgs e);
+    }
+
+    public class PhotonDiagnostics
+    {
+        public static IPhotonDiagnostics? Sink;
+
+        [Conditional("PHOTON_DIAGNOSTICS")]
+        public static void Emit(DiagnosticEventArgs e)
+        {
+            e.StackFrame = new StackFrame(1, true);
+            e.MethodInfo = e.StackFrame.GetMethod() as MethodInfo;
+
+            Sink?.OnEvent(e);
+        }
+    }
+}

--- a/PhotonUI/Photon.cs
+++ b/PhotonUI/Photon.cs
@@ -1,14 +1,14 @@
 ﻿using PhotonUI.Controls;
 using PhotonUI.Controls.Content;
+using PhotonUI.Diagnostics;
+using PhotonUI.Diagnostics.Events;
+using PhotonUI.Diagnostics.Events.Framework;
 using PhotonUI.Extensions;
 using PhotonUI.Models;
 using PhotonUI.Models.Properties;
 using PhotonUI.Services;
 using SDL3;
-using System.Diagnostics;
 using System.Numerics;
-using System.Reflection;
-using System.Text;
 
 namespace PhotonUI
 {
@@ -16,38 +16,56 @@ namespace PhotonUI
     {
         public static Window GetWindow(Control control)
         {
-            Control? current = control;
+            PhotonDiagnostics.Emit(new PhotonMethodEventArgs([control], DiagnosticPhase.Start));
 
-            while (current.Parent != null)
-                current = current.Parent;
+            try
+            {
+                Control? current = control;
 
-            if (current is Window window)
-                return window;
+                while (current.Parent != null)
+                    current = current.Parent;
 
-            throw new InvalidOperationException("Window not found");
+                if (current is Window window)
+                    return window;
+
+                throw new InvalidOperationException("Window not found");
+            }
+            finally
+            {
+                PhotonDiagnostics.Emit(new PhotonMethodEventArgs([control], DiagnosticPhase.End));
+            }
         }
         public static void InvalidateRenderChain(Control control)
         {
-            if (!control.IsInitialized) return;
+            PhotonDiagnostics.Emit(new PhotonMethodEventArgs([control], DiagnosticPhase.Start));
 
-            Control? boundary = null;
-
-            control.Parent?.BubbleControls(ancestor =>
+            try
             {
-                ancestor.IsRenderDirty = true;
+                if (!control.IsInitialized) return;
 
-                if (ancestor.IsVisible && ancestor.IsOpaque)
+                Control? boundary = null;
+
+                control.Parent?.BubbleControls(ancestor =>
                 {
-                    boundary = ancestor;
-                    return false;
-                }
-                return true;
-            });
+                    ancestor.IsRenderDirty = true;
 
-            boundary ??= Photon.GetWindow(control);
+                    if (ancestor.IsVisible && ancestor.IsOpaque)
+                    {
+                        boundary = ancestor;
+                        return false;
+                    }
+                    return true;
+                });
 
-            boundary.RequestRender(false);
-            boundary.IsBoundryDirty = true;
+                boundary ??= Photon.GetWindow(control);
+
+                boundary.RequestRender(false);
+                boundary.IsBoundryDirty = true;
+            }
+            finally
+            {
+                PhotonDiagnostics.Emit(new PhotonMethodEventArgs([control], DiagnosticPhase.End));
+            }
         }
 
         public static SDL.FRect ScaleRect(SDL.FRect rect, Vector2 scale, SDL.FPoint anchor)
@@ -142,111 +160,6 @@ namespace PhotonUI
 
             return new Size(targetW, targetH);
         }
-
-        #region Photon: Diagnostics
-
-        public static string BuildCompactStackLine(int trimStartCalls = 0)
-        {
-            StackTrace stackTrace = new(skipFrames: 2, fNeedFileInfo: false);
-            StackFrame[]? frames = stackTrace.GetFrames();
-
-            if (frames == null)
-                return "stack: []";
-
-            List<string> parts = [];
-
-            foreach (StackFrame? frame in frames.Reverse())
-            {
-                MethodBase? method = frame.GetMethod();
-                if (method == null)
-                    continue;
-
-                string typeName = method.DeclaringType?.Name ?? "UnknownType";
-                string methodName = method.Name;
-
-                if (methodName.Contains('<'))
-                {
-                    int startBracket = methodName.IndexOf('<') + 1;
-                    int endBracket = methodName.IndexOf('>');
-                    if (endBracket > 0)
-                        methodName = methodName[startBracket..endBracket];
-                }
-
-                if (typeName.Contains('<'))
-                {
-                    int startBracket = typeName.IndexOf('<') + 1;
-                    int endBracket = typeName.IndexOf('>');
-                    if (endBracket > 0)
-                        typeName = typeName[startBracket..endBracket];
-                    if (string.IsNullOrEmpty(typeName))
-                        typeName = "Anon";
-                }
-
-                parts.Add($"{typeName}.{methodName}");
-            }
-
-            parts = [.. parts.Select(p => p.Contains(".TunnelControls") ? "Tunneling" : p)];
-
-            for (int i = 0; i < parts.Count - 1;)
-            {
-                if (parts[i] == "Tunneling")
-                {
-                    int collapseEnd = i;
-
-                    while (collapseEnd < parts.Count && parts[collapseEnd] == "Tunneling")
-                        collapseEnd++;
-
-                    if (collapseEnd > i + 1)
-                        parts.RemoveRange(i + 1, collapseEnd - i - 1);
-                }
-
-                i++;
-            }
-
-            if (trimStartCalls > 0 && trimStartCalls < parts.Count)
-                parts = [.. parts.Skip(trimStartCalls)];
-
-            return $"stack: {string.Join("→", parts)}";
-        }
-
-        public static string GetLayoutData(Control? control, Func<string>? additional = null)
-        {
-            if (control == null) return "Error: No control provided!";
-
-            StringBuilder data = new();
-
-            string stack = BuildCompactStackLine(3);
-            string phase = string.Empty;
-
-            if (stack.Contains("ApplyIntrinsicRequests"))
-                phase = "FrameworkIntrinsic";
-            else if (stack.Contains("ApplyMeasureRequests"))
-                phase = "FrameworkMeasure";
-            else if (stack.Contains("ApplyArrangeRequests"))
-                phase = "FrameworkArrange";
-            else if (stack.Contains("ApplyRenderRequests"))
-                phase = "FrameworkRender";
-
-            data.AppendLine($"layout: {control.Name} :: {control.GetType().Name}");
-            data.Append("  ");
-            data.Append($"phase: {phase}\n");
-
-            data.Append("  ");
-            data.Append($"intrinsic=({control.IntrinsicSize.Width:F1},{control.IntrinsicSize.Height:F1}), ");
-            data.Append($"draw=({control.DrawRect.X},{control.DrawRect.Y},{control.DrawRect.W},{control.DrawRect.H})\n");
-
-            data.Append("  ");
-            data.Append($"margin=({control.Margin.Left},{control.Margin.Top},{control.Margin.Right},{control.Margin.Bottom}), ");
-            data.Append($"padding=({control.Padding.Left},{control.Padding.Top},{control.Padding.Right},{control.Padding.Bottom}), ");
-            data.Append($"minmax=({control.MinWidth},{control.MinHeight},{control.MaxWidth},{control.MaxHeight})\n");
-
-            if (additional is not null)
-                data.AppendLine(additional());
-
-            return data.ToString();
-        }
-
-        #endregion
 
         #region Photon: Hit Testing
 
@@ -350,22 +263,31 @@ namespace PhotonUI
         }
         public static Control? ResolveHitControl(Window window, float px, float py)
         {
-            List<Control> hits = GetHitControls(window, px, py);
+            PhotonDiagnostics.Emit(new PhotonMethodEventArgs([window, px, py], DiagnosticPhase.Start));
 
-            if (hits == null || hits.Count == 0)
+            try
+            {
+                List<Control> hits = GetHitControls(window, px, py);
+
+                if (hits == null || hits.Count == 0)
+                    return null;
+
+                IOrderedEnumerable<Control> ordered = hits
+                    .Where(c => c.IsVisible && c.IsHitTestVisible)
+                    .OrderByDescending(GetAncestorPath)
+                    .ThenByDescending(c => c.ZIndex)
+                    .ThenByDescending(GetControlDepth);
+
+                foreach (Control control in ordered)
+                    if (AncestorHitTest(control, px, py))
+                        return control;
+
                 return null;
-
-            IOrderedEnumerable<Control> ordered = hits
-                .Where(c => c.IsVisible && c.IsHitTestVisible)
-                .OrderByDescending(GetAncestorPath)
-                .ThenByDescending(c => c.ZIndex)
-                .ThenByDescending(GetControlDepth);
-
-            foreach (Control control in ordered)
-                if (AncestorHitTest(control, px, py))
-                    return control;
-
-            return null;
+            }
+            finally
+            {
+                PhotonDiagnostics.Emit(new PhotonMethodEventArgs([window, px, py], DiagnosticPhase.End));
+            }
         }
 
         #endregion

--- a/PhotonUI/PhotonUI.csproj
+++ b/PhotonUI/PhotonUI.csproj
@@ -8,13 +8,14 @@
 		<Company>Enterlucent</Company>
 		<Authors>Enterlucent</Authors>
 		<Product>PhotonUI</Product>
-		<Description>SDL3 based MVVM library for creating cross platform UI/UX </Description>
+		<Description>SDL3 based MVVM library for creating cross platform UI/UX</Description>
 		<Copyright>© 2026 Enterlucent</Copyright>
 
 		<AssemblyTitle>PhotonUI</AssemblyTitle>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<FileVersion>1.0.0.0</FileVersion>
 		<InformationalVersion>1.0.0</InformationalVersion>
+		<Configurations>Debug;Release;Diagnostics;Diagnose</Configurations>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -36,5 +37,15 @@
 		<PackageReference Include="SDL3-CS.Native.Mixer" Version="2.8.1.1" />
 		<PackageReference Include="SDL3-CS.Native.TTF" Version="3.2.2" />
 	</ItemGroup>
+
+	<!-- Debug build: normal debugging, no diagnostics -->
+	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+		<DefineConstants>DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<!-- Diagnose build: debugging + diagnostics -->
+	<PropertyGroup Condition="'$(Configuration)' == 'Diagnose'">
+		<DefineConstants>DEBUG;PHOTON_DIAGNOSTICS</DefineConstants>
+	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The implementation adds a fully optional, compile‑time‑gated diagnostics pipeline that allows PhotonUI to emit structured telemetry about internal framework operations without introducing any logging dependencies into the core library.

Key elements included in this PR:

- A new `DiagnosticEventArgs` hierarchy representing framework, control, method, and platform events
- A centralized emission point via `PhotonDiagnostics.Emit`
- A compile‑time flag (`PHOTON_DIAGNOSTICS`) that completely removes diagnostics from non‑diagnostic builds
- A new `Diagnose` build configuration for enabling diagnostics
- Integration of diagnostic emission across the control lifecycle (measure, arrange, render, tick, events, initialization, bubbling, tunneling, etc.)
- A host‑side XML diagnostics sink (`DiagnosticXMLSink`) that demonstrates how consumers can opt‑in and process diagnostic events
- Dependency injection wiring for the sink in the Desktop host
- Optional grouping, filtering, timestamping, and parameter capture in the sink
- No runtime overhead in Release or Debug builds unless diagnostics are explicitly enabled

This framework provides a foundation for logging, visualization tools, profilers, and automated testing instrumentation without impacting performance or introducing external dependencies into the core PhotonUI library.

## Related Issue
- Resolves #88

## Motivation and Context
The diagnostics system enables developers to observe and analyze internal framework behavior such as layout passes, rendering invalidation, event bubbling, and control lifecycle transitions.  

This is essential for debugging complex UI behavior, building visualization tools, and supporting advanced host‑side instrumentation — all while keeping the core library lightweight and dependency‑free.

The design ensures:
- Zero overhead when diagnostics are disabled
- Full control by host applications
- Structured, machine‑readable event output
- A consistent and extensible event model across the framework

## How Has This Been Tested?
Diagnostics were tested manually within the Desktop host application using the new `Diagnose` configuration.  
Verification included:

- Ensuring diagnostic events are emitted only when `PHOTON_DIAGNOSTICS` is defined
- Confirming Start/End event pairing across all instrumented methods
- Validating XML output structure, grouping, and filtering behavior
- Exercising control lifecycle operations (measure, arrange, render, tick)
- Triggering platform events and verifying platform event emission
- Confirming that Release and Debug builds produce no diagnostic output and incur no overhead

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Asset change (adds or updates icons, templates, or other assets)
- [ ] Documentation change (adds or updates documentation)
- [ ] Plugin change (adds or updates a plugin)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the core logic.
  - [x] I have linked the project issue above.
- [ ] My change requires a change to the assets.
  - [ ] I have linked the asset issue above.
- [ ] My change requires a change to the documentation.
  - [ ] I have linked the documentation issue above.
- [ ] My change requires a change to a plugin.
  - [ ] I have linked the plugin issue above.
